### PR TITLE
Refine reservation repository filters

### DIFF
--- a/QLine.Application/Features/Reservations/Queries/GetMyReservationsQuery.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetMyReservationsQuery.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
 
 namespace QLine.Application.Features.Reservations.Queries
 {
-    public class GetMyReservationsQuery
-    {
-    }
+    public sealed record GetMyReservationsQuery(Guid UserId) : IRequest<IReadOnlyList<ReservationDto>>;
 }

--- a/QLine.Application/Features/Reservations/Queries/GetMyReservationsQueryHandler.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetMyReservationsQueryHandler.cs
@@ -3,10 +3,48 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
+using QLine.Domain.Abstractions;
 
 namespace QLine.Application.Features.Reservations.Queries
 {
-    public class GetMyReservationsQueryHandler
+    public sealed class GetMyReservationsQueryHandler
+        : IRequestHandler<GetMyReservationsQuery, IReadOnlyList<ReservationDto>>
     {
+        private readonly IReservationRepository _reservations;
+        private readonly IQueueEntryRepository _queueEntries;
+
+        public GetMyReservationsQueryHandler(
+            IReservationRepository reservations,
+            IQueueEntryRepository queueEntries)
+        {
+            _reservations = reservations;
+            _queueEntries = queueEntries;
+        }
+
+        public async Task<IReadOnlyList<ReservationDto>> Handle(GetMyReservationsQuery request, CancellationToken ct)
+        {
+            var reservations = await _reservations.GetByUserAsync(request.UserId, ct);
+
+            var entries = await Task.WhenAll(reservations.Select(async r => new
+            {
+                Reservation = r,
+                Entry = await _queueEntries.GetByReservationAsync(r.Id, ct)
+            }));
+
+            return entries
+                .Select(x => new ReservationDto
+                {
+                    Id = x.Reservation.Id,
+                    ServicePointId = x.Reservation.ServicePointId,
+                    ServiceId = x.Reservation.ServiceId,
+                    UserId = x.Reservation.UserId,
+                    StartTime = x.Reservation.StartTime,
+                    Status = x.Reservation.Status.ToString(),
+                    TicketNo = x.Entry?.TicketNo
+                })
+                .ToList();
+        }
     }
 }

--- a/QLine.Application/Features/Reservations/Queries/GetReservationDetailsQueryHandler.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetReservationDetailsQueryHandler.cs
@@ -10,7 +10,7 @@ using QLine.Domain.Abstractions;
 
 namespace QLine.Application.Features.Reservations.Queries
 {
-    public sealed class GetReservationDetailsQueryHandler 
+    public sealed class GetReservationDetailsQueryHandler
         : IRequestHandler<GetReservationDetailsQuery, ReservationDto>
     {
         private readonly IReservationRepository _reservations;
@@ -29,11 +29,7 @@ namespace QLine.Application.Features.Reservations.Queries
             var res = await _reservations.GetByIdAsync(request.ReservationId, ct)
                 ?? throw new DomainException("Reservation not found.");
 
-            string? ticketNo = null;
-
-            var list = await _queueEntries.GetWaitingByServicePointAsync(res.ServicePointId, ct);
-            var linked = list.FirstOrDefault(q => q.ReservationId == res.Id);
-            ticketNo = linked?.TicketNo;
+            var linked = await _queueEntries.GetByReservationAsync(res.Id, ct);
 
             return new ReservationDto()
             {
@@ -43,7 +39,7 @@ namespace QLine.Application.Features.Reservations.Queries
                 UserId = res.UserId,
                 StartTime = res.StartTime,
                 Status = res.Status.ToString(),
-                TicketNo = ticketNo
+                TicketNo = linked?.TicketNo
             };
         }
     }

--- a/QLine.Domain/Abstractions/IQueueEntryRepository.cs
+++ b/QLine.Domain/Abstractions/IQueueEntryRepository.cs
@@ -11,6 +11,7 @@ namespace QLine.Domain.Abstractions
     {
         Task AddAsync(QueueEntry entry, CancellationToken ct);
         Task<QueueEntry?> GetByIdAsync(Guid id, CancellationToken ct);
+        Task<QueueEntry?> GetByReservationAsync(Guid reservationId, CancellationToken ct);
         Task<IReadOnlyList<QueueEntry>> GetWaitingByServicePointAsync(Guid servicePointId, CancellationToken ct);
         Task<QueueEntry?> GetCurrentInServiceByServicePointAsync(Guid servicePointId, CancellationToken ct);
         Task<QueueEntry?> GetFirstWaitingByServicePointAsync(Guid servicePointId, CancellationToken ct);

--- a/QLine.Domain/Abstractions/IReservationRepository.cs
+++ b/QLine.Domain/Abstractions/IReservationRepository.cs
@@ -17,5 +17,6 @@ namespace QLine.Domain.Abstractions
 
         Task AddAsync(Reservation reservation, CancellationToken ct);
         Task<Reservation?> GetByIdAsync(Guid id, CancellationToken ct);
+        Task<IReadOnlyList<Reservation>> GetByUserAsync(Guid userId, CancellationToken ct);
     }
 }

--- a/QLine.Infrastructure/Persistence/Repositories/QueueEntryRepository.cs
+++ b/QLine.Infrastructure/Persistence/Repositories/QueueEntryRepository.cs
@@ -25,6 +25,9 @@ namespace QLine.Infrastructure.Persistence.Repositories
         public Task<QueueEntry?> GetByIdAsync(Guid id, CancellationToken ct) =>
             _db.QueueEntries.FirstOrDefaultAsync(q => q.Id == id, ct);
 
+        public Task<QueueEntry?> GetByReservationAsync(Guid reservationId, CancellationToken ct) =>
+            _db.QueueEntries.AsNoTracking().FirstOrDefaultAsync(q => q.ReservationId == reservationId, ct);
+
         public Task<QueueEntry?> GetCurrentInServiceByServicePointAsync(Guid servicePointId, CancellationToken ct) =>
             _db.QueueEntries.FirstOrDefaultAsync(q => q.ServicePointId == servicePointId && q.Status == QueueStatus.InService, ct);
 
@@ -48,7 +51,7 @@ namespace QLine.Infrastructure.Persistence.Repositories
             var next = await _db.QueueEntries
                 .FromSqlInterpolated($@"
                     SELECT * FROM ""QueueEntries""
-                    WHERE ""ServicePointId"" = {servicePointId} 
+                    WHERE ""ServicePointId"" = {servicePointId}
                       AND ""Status"" = {(int)QueueStatus.Waiting}
                     ORDER BY ""Priority"" DESC, ""CreatedAt""
                     FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
## Summary
- add reservation retrieval by user and queue entries by reservation, removing implicit tenant scoping
- simplify reservation slot availability check and use targeted queue lookups in reservation details handler
- implement GetMyReservations query to return user reservations with ticket numbers

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c4ba47b483209860a5042736a403)