### PR TITLE
Refine AppUser creation without placeholder hashes

### DIFF
--- a/QLine.Domain/Entities/AppUser.cs
+++ b/QLine.Domain/Entities/AppUser.cs
@@ -28,22 +28,29 @@ namespace QLine.Domain.Entities
             string email,
             string firstName,
             string lastName,
-            string passwordHash,
+            string? passwordHash,
             UserRole role)
         {
             if (id == Guid.Empty) throw new DomainException("AppUser Id cannot be empty.");
             if (string.IsNullOrWhiteSpace(email)) throw new DomainException("AppUser Email is required.");
             if (string.IsNullOrWhiteSpace(firstName)) throw new DomainException("AppUser FirstName is required.");
             if (string.IsNullOrWhiteSpace(lastName)) throw new DomainException("AppUser LastName is required.");
-            if (string.IsNullOrWhiteSpace(passwordHash)) throw new DomainException("AppUser PasswordHash is required.");
 
             Id = id;
             Email = email.Trim();
             FirstName = firstName.Trim();
             LastName = lastName.Trim();
-            PasswordHash = passwordHash.Trim();
+            PasswordHash = passwordHash?.Trim() ?? string.Empty;
             Role = role;
         }
+
+        public static AppUser Create(
+            Guid id,
+            string email,
+            string firstName,
+            string lastName,
+            UserRole role)
+            => new(id, email, firstName, lastName, null, role);
 
         public static AppUser Create(
             Guid id,

--- a/QLine.Infrastructure/Persistence/DbInitializer.cs
+++ b/QLine.Infrastructure/Persistence/DbInitializer.cs
@@ -46,18 +46,18 @@ namespace QLine.Infrastructure.Persistence
                 email: "test.client@qline.local",
                 firstName: "Test",
                 lastName: "Client",
-                passwordHash: passwordHasher.HashPassword(null!, demoPassword),
                 role: UserRole.Client
             );
+            user.UpdatePasswordHash(passwordHasher.HashPassword(user, demoPassword));
 
             var staff = AppUser.Create(
                 id: staffId,
                 email: "staff@qline.local",
                 firstName: "Demo",
                 lastName: "Staff",
-                passwordHash: passwordHasher.HashPassword(null!, demoPassword),
                 role: UserRole.Staff
             );
+            staff.UpdatePasswordHash(passwordHasher.HashPassword(staff, demoPassword));
 
             await db.ServicePoints.AddAsync(sp, ct);
             await db.Services.AddAsync(svc, ct);

--- a/QLine.Web/Components/Layout/NavMenu.razor
+++ b/QLine.Web/Components/Layout/NavMenu.razor
@@ -63,6 +63,9 @@
                     <NavLink class="nav-link" href="/login">
                         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Login
                     </NavLink>
+                    <NavLink class="nav-link" href="/register">
+                        <span class="bi bi-person-plus" aria-hidden="true"></span> Register
+                    </NavLink>
                 </NotAuthorized>
             </AuthorizeView>
         </div>

--- a/QLine.Web/Components/Pages/Auth/Register.razor
+++ b/QLine.Web/Components/Pages/Auth/Register.razor
@@ -1,0 +1,35 @@
+@page "/register"
+@inject NavigationManager Nav
+
+<h3>Register</h3>
+
+@if (ErrorCode is not null)
+{
+        <p class="text-danger">@ErrorMessage</p>
+}
+
+<form method="post" action="/auth/register">
+        <input type="text" name="firstName" value="@_firstName" placeholder="First name" />
+        <input type="text" name="lastName" value="@_lastName" placeholder="Last name" style="margin-left:8px;" />
+        <input type="email" name="email" value="@_email" placeholder="email" style="margin-left:8px;" />
+        <input type="password" name="password" value="@_password" placeholder="password" style="margin-left:8px;" />
+        <button type="submit" style="margin-left:8px;">Create account</button>
+</form>
+
+@code {
+        private string _firstName = "";
+        private string _lastName = "";
+        private string _email = "";
+        private string _password = "";
+
+        private string? ErrorCode => new Uri(Nav.Uri).Query.Contains("error=")
+                ? System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query).Get("error")
+                : null;
+
+        private string ErrorMessage => ErrorCode switch
+        {
+                "exists" => "A user with this email already exists",
+                "invalid" => "Please complete all fields",
+                _ => "Registration failed"
+        };
+}

--- a/QLine.Web/Components/Routes.razor
+++ b/QLine.Web/Components/Routes.razor
@@ -1,16 +1,16 @@
-﻿@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 
 <CascadingAuthenticationState>
-	<Router AppAssembly="@typeof(App).Assembly">
-		<Found Context="routeData">
-			<RouteView RouteData="@routeData" DefaultLayout="@typeof(Components.Layout.MainLayout)" />
-			<FocusOnNavigate RouteData="@routeData" Selector="h1" />
-		</Found>
-		<NotFound>
-			<PageTitle>Not found</PageTitle>
-			<LayoutView Layout="@typeof(Components.Layout.MainLayout)">
-				<p role="alert">Sorry, there's nothing at this address.</p>
-			</LayoutView>
-		</NotFound>
-	</Router>
+        <Router AppAssembly="@typeof(App).Assembly">
+                <Found Context="routeData">
+                        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Components.Layout.MainLayout)" />
+                        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+                </Found>
+                <NotFound>
+                        <PageTitle>Not found</PageTitle>
+                        <LayoutView Layout="@typeof(Components.Layout.MainLayout)">
+                                <p role="alert">Sorry, there's nothing at this address.</p>
+                        </LayoutView>
+                </NotFound>
+        </Router>
 </CascadingAuthenticationState>

--- a/QLine.Web/Endpoints/AuthEndpoints.cs
+++ b/QLine.Web/Endpoints/AuthEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using QLine.Domain.Abstractions;
 using QLine.Domain.Entities;
+using QLine.Domain.Enums;
 using System.Security.Claims;
 
 namespace QLine.Web.Endpoints
@@ -43,6 +44,50 @@ namespace QLine.Web.Endpoints
                 await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
 
                 return Results.Redirect(string.IsNullOrWhiteSpace(returnUrl) ? "/staff/queue" : returnUrl);
+            });
+
+            app.MapPost("/auth/register", [IgnoreAntiforgeryToken] async (
+                HttpContext http,
+                IAppUserRepository users,
+                IPasswordHasher<AppUser> passwordHasher) =>
+            {
+                var form = await http.Request.ReadFormAsync();
+                var firstName = form["firstName"].ToString();
+                var lastName = form["lastName"].ToString();
+                var email = form["email"].ToString();
+                var password = form["password"].ToString();
+
+                if (string.IsNullOrWhiteSpace(firstName)
+                    || string.IsNullOrWhiteSpace(lastName)
+                    || string.IsNullOrWhiteSpace(email)
+                    || string.IsNullOrWhiteSpace(password))
+                {
+                    return Results.Redirect("/register?error=invalid");
+                }
+
+                var existingUser = await users.GetByEmailAsync(email, http.RequestAborted);
+                if (existingUser is not null)
+                    return Results.Redirect("/register?error=exists");
+
+                var user = AppUser.Create(Guid.NewGuid(), email, firstName, lastName, UserRole.Client);
+                var passwordHash = passwordHasher.HashPassword(user, password);
+                user.UpdatePasswordHash(passwordHash);
+
+                await users.AddAsync(user, http.RequestAborted);
+
+                var claims = new List<Claim>
+                {
+                    new(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                    new(ClaimTypes.Email, user.Email),
+                    new(ClaimTypes.Name, user.FullName),
+                    new(ClaimTypes.Role, user.Role.ToString())
+                };
+                var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+                var principal = new ClaimsPrincipal(identity);
+
+                await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+
+                return Results.Redirect("/");
             });
 
             app.MapPost("/auth/logout", [IgnoreAntiforgeryToken] async (HttpContext http) =>


### PR DESCRIPTION
## Summary
- allow creating AppUser instances without an initial password hash to avoid placeholders
- hash passwords using the constructed user during registration and database seeding

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d5ea1dc48320bd86ba8797d5c58d)