### PR TITLE
Refactor account endpoints to use CQRS delete command

### DIFF
--- a/QLine.Application/Features/Account/Commands/DeleteAccountCommand.cs
+++ b/QLine.Application/Features/Account/Commands/DeleteAccountCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace QLine.Application.Features.Account.Commands
+{
+    public sealed record DeleteAccountCommand(Guid UserId, string Password) : IRequest;
+}

--- a/QLine.Application/Features/Account/Commands/DeleteAccountCommandHandler.cs
+++ b/QLine.Application/Features/Account/Commands/DeleteAccountCommandHandler.cs
@@ -1,0 +1,57 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using QLine.Domain;
+using QLine.Domain.Entities;
+using QLine.Domain.Enums;
+using QLine.Infrastructure.Persistence;
+
+namespace QLine.Application.Features.Account.Commands
+{
+    public sealed class DeleteAccountCommandHandler : IRequestHandler<DeleteAccountCommand>
+    {
+        private readonly AppDbContext _db;
+        private readonly IPasswordHasher<AppUser> _passwordHasher;
+
+        public DeleteAccountCommandHandler(AppDbContext db, IPasswordHasher<AppUser> passwordHasher)
+        {
+            _db = db;
+            _passwordHasher = passwordHasher;
+        }
+
+        public async Task Handle(DeleteAccountCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _db.AppUsers.FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+            if (user is null)
+            {
+                throw new DomainException("User not found.");
+            }
+
+            var verify = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, request.Password);
+            if (verify is not PasswordVerificationResult.Success and not PasswordVerificationResult.SuccessRehashNeeded)
+            {
+                throw new DomainException("Invalid password.");
+            }
+
+            var reservations = await _db.Reservations
+                .Where(r => r.UserId == request.UserId)
+                .ToListAsync(cancellationToken);
+
+            foreach (var reservation in reservations.Where(r => r.Status == ReservationStatus.Active))
+            {
+                reservation.Cancel();
+            }
+
+            var reservationIds = reservations.Select(r => r.Id).ToList();
+            var queueEntries = await _db.QueueEntries
+                .Where(q => reservationIds.Contains(q.ReservationId))
+                .ToListAsync(cancellationToken);
+
+            _db.QueueEntries.RemoveRange(queueEntries);
+            _db.Reservations.RemoveRange(reservations);
+            _db.AppUsers.Remove(user);
+
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/QLine.Domain/Abstractions/IAppUserRepository.cs
+++ b/QLine.Domain/Abstractions/IAppUserRepository.cs
@@ -12,5 +12,6 @@ namespace QLine.Domain.Abstractions
         Task<AppUser?> GetByIdAsync(Guid id, CancellationToken ct);
         Task<AppUser?> GetByEmailAsync(string email, CancellationToken ct);
         Task AddAsync (AppUser user, CancellationToken ct);
+        Task UpdateAsync(AppUser user, CancellationToken ct);
     }
 }

--- a/QLine.Infrastructure/Persistence/Repositories/AppUserRepository.cs
+++ b/QLine.Infrastructure/Persistence/Repositories/AppUserRepository.cs
@@ -15,15 +15,21 @@ namespace QLine.Infrastructure.Persistence.Repositories
         public AppUserRepository(AppDbContext db) => _db = db;
 
         public Task<AppUser?> GetByIdAsync(Guid id, CancellationToken ct) =>
-            _db.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == id, ct);
+            _db.AppUsers.FirstOrDefaultAsync(u => u.Id == id, ct);
 
         public Task<AppUser?> GetByEmailAsync(string email, CancellationToken ct) =>
-            _db.AppUsers.AsNoTracking()
+            _db.AppUsers
                 .FirstOrDefaultAsync(u => u.Email == email, ct);
-        
+
         public async Task AddAsync(AppUser user, CancellationToken ct)
         {
             await _db.AppUsers.AddAsync(user, ct);
+            await _db.SaveChangesAsync(ct);
+        }
+
+        public async Task UpdateAsync(AppUser user, CancellationToken ct)
+        {
+            _db.AppUsers.Update(user);
             await _db.SaveChangesAsync(ct);
         }
     }

--- a/QLine.Web/Components/Layout/NavMenu.razor
+++ b/QLine.Web/Components/Layout/NavMenu.razor
@@ -55,6 +55,9 @@
         <div class="nav-item px-3">
             <AuthorizeView>
                 <Authorized>
+                    <NavLink class="nav-link" href="/profile">
+                        <span class="bi bi-person" aria-hidden="true"></span> Profile
+                    </NavLink>
                     <NavLink class="nav-link" href="/logout">
                         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Logout
                     </NavLink>

--- a/QLine.Web/Components/Pages/Profile.razor
+++ b/QLine.Web/Components/Pages/Profile.razor
@@ -1,0 +1,158 @@
+@page "/profile"
+@attribute [Authorize]
+@using System.Web
+@using QLine.Application.Abstractions
+@using QLine.Domain.Entities
+@inject IAppUserRepository Users
+@inject ICurrentUser CurrentUser
+@inject NavigationManager Nav
+
+<h3>Profile</h3>
+
+@if (!string.IsNullOrWhiteSpace(_successMessage))
+{
+    <p class="text-success">@_successMessage</p>
+}
+@if (_errorMessages.Count > 0)
+{
+    @foreach (var message in _errorMessages)
+    {
+        <p class="text-danger">@message</p>
+    }
+}
+
+@if (_user is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <div class="profile-card">
+        <div class="profile-field">
+            <label>First Name</label>
+            <input readonly value="@_user.FirstName" />
+        </div>
+        <div class="profile-field">
+            <label>Last Name</label>
+            <input readonly value="@_user.LastName" />
+        </div>
+        <div class="profile-field">
+            <label>Email</label>
+            <input readonly value="@_user.Email" />
+        </div>
+    </div>
+
+    <section class="profile-actions">
+        <div class="change-password">
+            <button type="button" @onclick="ToggleChangePassword">Change Password</button>
+
+            @if (_showChangePassword)
+            {
+                <form method="post" action="/account/change-password" class="password-form">
+                    <label for="current-password">Password</label>
+                    <input id="current-password" name="password" type="password" />
+
+                    <label for="new-password">New Password</label>
+                    <input id="new-password" name="newPassword" type="password" />
+
+                    <label for="confirm-password">Confirm New Password</label>
+                    <input id="confirm-password" name="confirmPassword" type="password" />
+
+                    <button type="submit">Save</button>
+                </form>
+            }
+        </div>
+
+        <div class="remove-account">
+            <button type="button" class="danger" @onclick="ShowDeleteDialog">Remove Account</button>
+        </div>
+    </section>
+}
+
+@if (_showDeleteDialog)
+{
+    <div class="modal-backdrop">
+        <div class="modal">
+            <h4>Remove Account</h4>
+            <p class="text-danger">Это действие необратимо.</p>
+            <form method="post" action="/account/delete" class="delete-form">
+                <label for="delete-password">Password</label>
+                <input id="delete-password" name="password" type="password" />
+
+                <div class="modal-actions">
+                    <button type="submit" class="danger">Confirm Removal</button>
+                    <button type="button" @onclick="HideDeleteDialog">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+}
+
+@code {
+    private AppUser? _user;
+    private bool _showChangePassword;
+    private bool _showDeleteDialog;
+    private string? _successMessage;
+    private List<string> _errorMessages = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (CurrentUser.UserId is Guid userId)
+        {
+            _user = await Users.GetByIdAsync(userId, CancellationToken.None);
+        }
+
+        ParseMessages();
+    }
+
+    protected override void OnParametersSet()
+    {
+        ParseMessages();
+    }
+
+    private void ParseMessages()
+    {
+        var query = HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query);
+
+        _successMessage = query.Get("pwdChanged") == "true"
+            ? "Password updated successfully."
+            : null;
+
+        _errorMessages = query.GetValues("pwdError") switch
+        {
+            null => new List<string>(),
+            var errors => errors
+                .Select(error => error switch
+                {
+                    "invalidCurrent" => "Current password is incorrect.",
+                    "invalid" => "Unable to change password. Please provide current, new, and confirmation passwords.",
+                    "confirmMismatch" => "New password and confirmation do not match.",
+                    _ => null
+                })
+                .Where(message => message is not null)
+                .Select(message => message!)
+                .ToList()
+        };
+
+        var deleteError = query.Get("deleteError") switch
+        {
+            "invalidPassword" => "Password is incorrect. Account not removed.",
+            "missingPassword" => "Please confirm removal by entering your password.",
+            _ => null
+        };
+
+        if (!string.IsNullOrWhiteSpace(deleteError))
+        {
+            _errorMessages.Add(deleteError);
+        }
+    }
+
+    private void ToggleChangePassword()
+    {
+        _showChangePassword = !_showChangePassword;
+    }
+
+    private void ShowDeleteDialog() => _showDeleteDialog = true;
+
+    private void HideDeleteDialog() => _showDeleteDialog = false;
+}

--- a/QLine.Web/Components/Pages/Profile.razor.css
+++ b/QLine.Web/Components/Pages/Profile.razor.css
@@ -1,0 +1,62 @@
+.profile-card {
+    display: grid;
+    gap: 12px;
+    max-width: 360px;
+    margin-bottom: 16px;
+}
+
+.profile-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.password-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: 320px;
+    margin-top: 8px;
+}
+
+.profile-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.danger {
+    background: #dc3545;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+}
+
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal {
+    background: white;
+    padding: 16px;
+    border-radius: 8px;
+    max-width: 400px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.delete-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}

--- a/QLine.Web/Endpoints/AccountEndpoints.cs
+++ b/QLine.Web/Endpoints/AccountEndpoints.cs
@@ -1,0 +1,86 @@
+using MediatR;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using QLine.Application.Features.Account.Commands;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Entities;
+using System.Security.Claims;
+
+namespace QLine.Web.Endpoints
+{
+    public static class AccountEndpoints
+    {
+        public static void MapAccountEndpoints(this IEndpointRouteBuilder app)
+        {
+            app.MapPost("/account/change-password", [Authorize, IgnoreAntiforgeryToken] async (
+                HttpContext http,
+                IAppUserRepository users,
+                IPasswordHasher<AppUser> passwordHasher) =>
+            {
+                var form = await http.Request.ReadFormAsync();
+                var currentPassword = form["password"].ToString();
+                var newPassword = form["newPassword"].ToString();
+                var confirmPassword = form["confirmPassword"].ToString();
+
+                if (string.IsNullOrWhiteSpace(currentPassword) || string.IsNullOrWhiteSpace(newPassword))
+                {
+                    return Results.Redirect("/profile?pwdError=invalid");
+                }
+
+                if (!string.Equals(newPassword, confirmPassword, StringComparison.Ordinal))
+                {
+                    return Results.Redirect("/profile?pwdError=confirmMismatch");
+                }
+
+                var userIdValue = http.User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!Guid.TryParse(userIdValue, out var userId))
+                    return Results.Redirect("/login");
+
+                var user = await users.GetByIdAsync(userId, http.RequestAborted);
+                if (user is null)
+                    return Results.Redirect("/login");
+
+                var verify = passwordHasher.VerifyHashedPassword(user, user.PasswordHash, currentPassword);
+                if (verify is not PasswordVerificationResult.Success and not PasswordVerificationResult.SuccessRehashNeeded)
+                    return Results.Redirect("/profile?pwdError=invalidCurrent");
+
+                var newPasswordHash = passwordHasher.HashPassword(user, newPassword);
+                user.UpdatePasswordHash(newPasswordHash);
+                await users.UpdateAsync(user, http.RequestAborted);
+
+                return Results.Redirect("/profile?pwdChanged=true");
+            }).RequireAuthorization();
+
+            app.MapPost("/account/delete", [Authorize, IgnoreAntiforgeryToken] async (
+                HttpContext http,
+                IMediator mediator) =>
+            {
+                var form = await http.Request.ReadFormAsync();
+                var currentPassword = form["password"].ToString();
+
+                if (string.IsNullOrWhiteSpace(currentPassword))
+                {
+                    return Results.Redirect("/profile?deleteError=missingPassword");
+                }
+
+                var userIdValue = http.User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!Guid.TryParse(userIdValue, out var userId))
+                    return Results.Redirect("/login");
+
+                try
+                {
+                    await mediator.Send(new DeleteAccountCommand(userId, currentPassword), http.RequestAborted);
+                }
+                catch
+                {
+                    return Results.Redirect("/profile?deleteError=invalidPassword");
+                }
+
+                await http.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                return Results.Redirect("/login?accountRemoved=true");
+            }).RequireAuthorization();
+        }
+    }
+}

--- a/QLine.Web/Program.cs
+++ b/QLine.Web/Program.cs
@@ -74,6 +74,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapAuthEndpoints();
+app.MapAccountEndpoints();
 
 app.MapHub<QueueHub>("/hubs/queue");
 


### PR DESCRIPTION
## Summary
- add a DeleteAccountCommand and handler that performs password-verified account cleanup through AppDbContext
- refactor account endpoints to use the user repository for password changes and MediatR for account deletion with password validation feedback

## Testing
- Not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ece8d040832097b68b7f3d971697)