### PR TITLE
Bind reservations to current user

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/CreateReservationCommand.cs
+++ b/QLine.Application/Features/Reservations/Commands/CreateReservationCommand.cs
@@ -1,17 +1,11 @@
-﻿using QLine.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MediatR;
 using QLine.Application.DTO;
+
 namespace QLine.Application.Features.Reservations.Commands
 {
     public sealed record CreateReservationCommand(
         Guid ServicePointId,
         Guid ServiceId,
-        Guid UserId,
         DateTimeOffset StartTime
         ) : IRequest<ReservationDto>;
 

--- a/QLine.Application/Validation/CreateReservationCommandValidator.cs
+++ b/QLine.Application/Validation/CreateReservationCommandValidator.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentValidation;
 using QLine.Application.Features.Reservations.Commands;
 
@@ -14,7 +9,6 @@ namespace QLine.Application.Validation
         {
             RuleFor(x => x.ServicePointId).NotEmpty();
             RuleFor(x => x.ServiceId).NotEmpty();
-            RuleFor(x => x.UserId).NotEmpty();
             RuleFor(x => x.StartTime).NotEqual(default(DateTimeOffset));
         }
     }

--- a/QLine.Web/Components/Pages/Reserve.razor
+++ b/QLine.Web/Components/Pages/Reserve.razor
@@ -1,4 +1,6 @@
-﻿@page "/reserve/{ServicePointId:guid}/{ServiceId:guid}"
+@page "/reserve/{ServicePointId:guid}/{ServiceId:guid}"
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using MediatR
 @using QLine.Application.Features.Reservations.Commands
@@ -9,59 +11,55 @@
 
 @if (_created is null)
 {
-	<EditForm Model="this" OnValidSubmit="CreateAsync">
-		<DataAnnotationsValidator />
-		<div>
-			<label>Start time (local): </label>
-			<input type="datetime-local" @bind="_startLocal"/>
-		</div>
-		<div style="margin-top:8px;">
-			<button type="submit">Create</button>
-		</div>
-		@if (!string.IsNullOrWhiteSpace(_errorMessage))
-		{
-			<ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
-		}
-	</EditForm>
+        <EditForm Model="this" OnValidSubmit="CreateAsync">
+                <DataAnnotationsValidator />
+                <div>
+                        <label>Start time (local): </label>
+                        <input type="datetime-local" @bind="_startLocal"/>
+                </div>
+                <div style="margin-top:8px;">
+                        <button type="submit">Create</button>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(_errorMessage))
+                {
+                        <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+                }
+        </EditForm>
 }
 else
 {
-	<h4>Reservation created</h4>
-	<p><strong>Id:</strong>@_created.Id</p>
-	<p><strong>Ticket:</strong>@_created.TicketNo</p>
-	<p><strong>Start (local):</strong><UtcDate Value="@_created.StartTime" /></p>
-	<p><small>UTC: @_created.StartTime.ToString("u")</small></p>
+        <h4>Reservation created</h4>
+        <p><strong>Id:</strong>@_created.Id</p>
+        <p><strong>Ticket:</strong>@_created.TicketNo</p>
+        <p><strong>Start (local):</strong><UtcDate Value="@_created.StartTime" /></p>
+        <p><small>UTC: @_created.StartTime.ToString("u")</small></p>
 }
 
 @code {
-	[Parameter] public Guid ServicePointId { get; set; }
-	[Parameter] public Guid ServiceId { get; set; }
+        [Parameter] public Guid ServicePointId { get; set; }
+        [Parameter] public Guid ServiceId { get; set; }
 
-    //Seeded Id from DbInititalizer
-    private static readonly Guid UserId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        private DateTime _startLocal = DateTime.Now.AddHours(1);
+        private ReservationDto? _created;
+        private string? _errorMessage;
+        private List<string>? _errorDetails;
 
-	private DateTime _startLocal = DateTime.Now.AddHours(1);
-	private ReservationDto? _created;
-	private string? _errorMessage;
-	private List<string>? _errorDetails;
-
-	private async Task CreateAsync()
-	{
-		try
-		{
-			_errorMessage = null;
-			_errorDetails = null;
+        private async Task CreateAsync()
+        {
+                try
+                {
+                        _errorMessage = null;
+                        _errorDetails = null;
                     var dto = await Mediator.Send(new CreateReservationCommand(
                             ServicePointId: ServicePointId,
                             ServiceId: ServiceId,
-                            UserId: UserId,
-				StartTime: new DateTimeOffset(_startLocal.ToUniversalTime())
-			));
-			_created = dto;
-		}
-		catch (Exception ex)
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
-	}
+                                StartTime: new DateTimeOffset(_startLocal.ToUniversalTime())
+                        ));
+                        _created = dto;
+                }
+                catch (Exception ex)
+                {
+                        (_errorMessage, _errorDetails) = ex.ToUserMessage();
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- use ICurrentUser in CreateReservationCommandHandler to require an authenticated user id
- remove user id from reservation command/validation and rely on the current user
- secure the Reserve page and stop sending a hard-coded user id when creating reservations


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946be30489483209fe07f5e4aa340e1)