### PR TITLE
Fix reservation overlap duration calculation

### DIFF
--- a/QLine.Application/DTO/SlotDto.cs
+++ b/QLine.Application/DTO/SlotDto.cs
@@ -8,5 +8,8 @@ namespace QLine.Application.DTO
 {
     public class SlotDto
     {
+        public TimeSpan Start { get; init; }
+        public TimeSpan End { get; init; }
+        public bool IsAvailable { get; init; }
     }
 }

--- a/QLine.Application/Features/Reservations/Queries/GetAvailableSlotsQuery.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetAvailableSlotsQuery.cs
@@ -4,9 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using MediatR;
+using QLine.Application.DTO;
+
 namespace QLine.Application.Features.Reservations.Queries
 {
-    public class GetAvailableSlotsQuery
-    {
-    }
+    public sealed record GetAvailableSlotsQuery(
+        Guid ServicePointId,
+        Guid ServiceId,
+        DateOnly Date
+    ) : IRequest<IReadOnlyList<SlotDto>>;
 }

--- a/QLine.Application/Features/Reservations/Queries/GetAvailableSlotsQueryHandler.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetAvailableSlotsQueryHandler.cs
@@ -1,12 +1,130 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.Json;
+using MediatR;
+using QLine.Application.DTO;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Entities;
 
 namespace QLine.Application.Features.Reservations.Queries
 {
-    public class GetAvailableSlotsQueryHandler
+    public sealed class GetAvailableSlotsQueryHandler
+        : IRequestHandler<GetAvailableSlotsQuery, IReadOnlyList<SlotDto>>
     {
+        private readonly IServicePointRepository _servicePoints;
+        private readonly IServiceRepository _services;
+        private readonly IReservationRepository _reservations;
+
+        public GetAvailableSlotsQueryHandler(
+            IServicePointRepository servicePoints,
+            IServiceRepository services,
+            IReservationRepository reservations)
+        {
+            _servicePoints = servicePoints;
+            _services = services;
+            _reservations = reservations;
+        }
+
+        public async Task<IReadOnlyList<SlotDto>> Handle(GetAvailableSlotsQuery request, CancellationToken ct)
+        {
+            var servicePoint = await _servicePoints.GetByIdAsync(request.ServicePointId, ct)
+                ?? throw new DomainException("Service Point not found.");
+
+            var service = await _services.GetByIdAsync(request.ServiceId, ct)
+                ?? throw new DomainException("Service not found.");
+
+            var openHours = TryGetWorkingHours(servicePoint, request.Date);
+            if (openHours is null)
+                return Array.Empty<SlotDto>();
+
+            var duration = TimeSpan.FromMinutes(service.DurationMin);
+            var reservations = await _reservations.GetByDayAsync(
+                request.ServicePointId,
+                request.ServiceId,
+                request.Date,
+                ct);
+
+            var takenSlots = reservations
+                .Select(r =>
+                {
+                    var reservationDuration = r.Service is not null
+                        ? TimeSpan.FromMinutes(r.Service.DurationMin)
+                        : duration;
+
+                    return (Start: r.StartTime.TimeOfDay, End: r.StartTime.TimeOfDay + reservationDuration);
+                })
+                .ToList();
+
+            var slots = new List<SlotDto>();
+
+            for (var start = openHours.Value.Opening; start + duration <= openHours.Value.Closing; start += duration)
+            {
+                var end = start + duration;
+                var overlapsReservation = takenSlots.Any(t => start < t.End && t.Start < end);
+
+                if (overlapsReservation)
+                    continue;
+
+                slots.Add(new SlotDto
+                {
+                    Start = start,
+                    End = end,
+                    IsAvailable = true
+                });
+            }
+
+            return slots;
+        }
+
+        private static (TimeSpan Opening, TimeSpan Closing)? TryGetWorkingHours(ServicePoint servicePoint, DateOnly date)
+        {
+            if (string.IsNullOrWhiteSpace(servicePoint.OpenHoursJson))
+                return null;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(servicePoint.OpenHoursJson);
+                var dayKey = date.DayOfWeek switch
+                {
+                    DayOfWeek.Monday => "monday",
+                    DayOfWeek.Tuesday => "tuesday",
+                    DayOfWeek.Wednesday => "wednesday",
+                    DayOfWeek.Thursday => "thursday",
+                    DayOfWeek.Friday => "friday",
+                    DayOfWeek.Saturday => "saturday",
+                    DayOfWeek.Sunday => "sunday",
+                    _ => string.Empty
+                };
+
+                if (string.IsNullOrWhiteSpace(dayKey))
+                    return null;
+
+                if (!doc.RootElement.TryGetProperty(dayKey, out var dayElement))
+                    return null;
+
+                if (dayElement.ValueKind != JsonValueKind.Object)
+                    return null;
+
+                var open = dayElement.TryGetProperty("open", out var openProp) && openProp.GetBoolean();
+                if (!open)
+                    return null;
+
+                if (!dayElement.TryGetProperty("start", out var startProp) ||
+                    !dayElement.TryGetProperty("end", out var endProp))
+                    return null;
+
+                if (!TimeSpan.TryParse(startProp.GetString(), out var opening) ||
+                    !TimeSpan.TryParse(endProp.GetString(), out var closing))
+                    return null;
+
+                if (opening >= closing)
+                    return null;
+
+                return (opening, closing);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 }

--- a/QLine.Domain/Abstractions/IReservationRepository.cs
+++ b/QLine.Domain/Abstractions/IReservationRepository.cs
@@ -15,6 +15,12 @@ namespace QLine.Domain.Abstractions
 
         Task<bool> IsSlotAvailableAsync(Guid servicePointId, DateTimeOffset startTime, CancellationToken ct);
 
+        Task<IReadOnlyList<Reservation>> GetByDayAsync(
+            Guid servicePointId,
+            Guid serviceId,
+            DateOnly date,
+            CancellationToken ct);
+
         Task AddAsync(Reservation reservation, CancellationToken ct);
         Task<Reservation?> GetByIdAsync(Guid id, CancellationToken ct);
         Task<IReadOnlyList<Reservation>> GetByUserAsync(Guid userId, CancellationToken ct);

--- a/QLine.Infrastructure/Persistence/Repositories/ReservationRepository.cs
+++ b/QLine.Infrastructure/Persistence/Repositories/ReservationRepository.cs
@@ -31,6 +31,24 @@ namespace QLine.Infrastructure.Persistence.Repositories
             await _db.SaveChangesAsync(ct);
         }
 
+        public async Task<IReadOnlyList<Reservation>> GetByDayAsync(
+            Guid servicePointId,
+            Guid serviceId,
+            DateOnly date,
+            CancellationToken ct)
+        {
+            var targetDate = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc).Date;
+
+            return await _db.Reservations.AsNoTracking()
+                .Include(r => r.Service)
+                .Where(r => r.ServicePointId == servicePointId
+                            && r.ServiceId == serviceId
+                            && r.Status == ReservationStatus.Active
+                            && r.StartTime.Date == targetDate)
+                .OrderBy(r => r.StartTime)
+                .ToListAsync(ct);
+        }
+
         public Task<Reservation?> GetByIdAsync(Guid id, CancellationToken ct) =>
             _db.Reservations.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, ct);
 


### PR DESCRIPTION
## Summary
- load reservation services when fetching daily reservations
- compute taken slot intervals using each reservation's actual service duration to prevent overlaps

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c61533408320b30212a49f568bb3)