### PR TITLE
Stop issuing tickets during reservation creation

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/CreateReservationCommandHandler.cs
+++ b/QLine.Application/Features/Reservations/Commands/CreateReservationCommandHandler.cs
@@ -4,7 +4,6 @@ using QLine.Application.Abstractions;
 using QLine.Application.DTO;
 using QLine.Domain;
 using QLine.Domain.Abstractions;
-using QLine.Domain.Entities;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
@@ -12,22 +11,16 @@ namespace QLine.Application.Features.Reservations.Commands
         : IRequestHandler<CreateReservationCommand, ReservationDto>
     {
         private readonly IReservationRepository _reservations;
-        private readonly IQueueEntryRepository _queueEntries;
         private readonly IDateTimeProvider _clock;
-        private readonly IRealtimeNotifier _realtime;
         private readonly ICurrentUser _currentUser;
 
         public CreateReservationCommandHandler(
             IReservationRepository reservations,
-            IQueueEntryRepository queueEntries,
             IDateTimeProvider clock,
-            IRealtimeNotifier realtime,
             ICurrentUser currentUser)
         {
             _reservations = reservations;
-            _queueEntries = queueEntries;
             _clock = clock;
-            _realtime = realtime;
             _currentUser = currentUser;
         }
 
@@ -59,20 +52,6 @@ namespace QLine.Application.Features.Reservations.Commands
 
             await _reservations.AddAsync(reservation, ct);
 
-            var ticketNo = GenerateTicketNo(request.ServicePointId);
-            var entry = QueueEntry.Create(
-                id: Guid.NewGuid(),
-                servicePointId: request.ServicePointId,
-                reservationId: reservation.Id,
-                ticketNo: ticketNo,
-                priority: 0,
-                createdAt: _clock.UtcNow
-            );
-
-            await _queueEntries.AddAsync(entry, ct);
-
-            await _realtime.QueueUpdated(request.ServicePointId, ct);
-
             return new ReservationDto
             {
                 Id = reservation.Id,
@@ -80,17 +59,8 @@ namespace QLine.Application.Features.Reservations.Commands
                 ServiceId = reservation.ServiceId,
                 UserId = reservation.UserId,
                 StartTime = reservation.StartTime,
-                Status = reservation.Status.ToString(),
-                TicketNo = entry.TicketNo
+                Status = reservation.Status.ToString()
             };
-        }
-
-        private static string GenerateTicketNo(Guid servicePointId)
-        {
-            var s = servicePointId.ToString("N");
-            var prefix = s.Substring(0, 3).ToUpperInvariant();
-            var suffix = Guid.NewGuid().ToString("N")[..4].ToUpperInvariant();
-            return $"{prefix}-{suffix}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop creating queue entries and ticket numbers when handling reservation creation
- return reservation data without including ticket numbers before check-in

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947678fdfbc8320a1868f5bf0f1b145)