### PR TITLE
Implement check-in by QR command

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/CheckInByQrCommand.cs
+++ b/QLine.Application/Features/Reservations/Commands/CheckInByQrCommand.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using MediatR;
+using QLine.Application.DTO;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
-    public class CheckInByQrCommand
-    {
-    }
+    public sealed record CheckInByQrCommand(Guid ReservationId) : IRequest<QueueSnapshotDto>;
 }

--- a/QLine.Application/Features/Reservations/Commands/CheckInByQrCommandHandler.cs
+++ b/QLine.Application/Features/Reservations/Commands/CheckInByQrCommandHandler.cs
@@ -1,12 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.Abstractions;
+using QLine.Application.DTO;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Entities;
+using QLine.Domain.Enums;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
-    public class CheckInByQrCommandHandler
+    public class CheckInByQrCommandHandler : IRequestHandler<CheckInByQrCommand, QueueSnapshotDto>
     {
+        private readonly IReservationRepository _reservations;
+        private readonly IQueueEntryRepository _queueEntries;
+        private readonly IDateTimeProvider _clock;
+        private readonly IRealtimeNotifier _realtime;
+
+        public CheckInByQrCommandHandler(
+            IReservationRepository reservations,
+            IQueueEntryRepository queueEntries,
+            IDateTimeProvider clock,
+            IRealtimeNotifier realtime)
+        {
+            _reservations = reservations;
+            _queueEntries = queueEntries;
+            _clock = clock;
+            _realtime = realtime;
+        }
+
+        public async Task<QueueSnapshotDto> Handle(CheckInByQrCommand request, CancellationToken ct)
+        {
+            var reservation = await _reservations.GetByIdAsync(request.ReservationId, ct);
+
+            if (reservation is null
+                || reservation.Status != ReservationStatus.Active
+                || reservation.StartTime.Date != _clock.UtcNow.Date)
+            {
+                throw new DomainException("Reservation QR code is invalid or expired.");
+            }
+
+            var existingEntry = await _queueEntries.GetByReservationAsync(reservation.Id, ct);
+            if (existingEntry is not null)
+            {
+                throw new DomainException("Reservation is already checked in.");
+            }
+
+            var ticketNo = GenerateTicketNumber(reservation);
+
+            var entry = QueueEntry.Create(
+                Guid.NewGuid(),
+                reservation.ServicePointId,
+                reservation.Id,
+                ticketNo,
+                priority: 0,
+                createdAt: _clock.UtcNow);
+
+            await _queueEntries.AddAsync(entry, ct);
+            await _realtime.QueueUpdated(entry.ServicePointId, ct);
+
+            var current = await _queueEntries.GetCurrentInServiceByServicePointAsync(entry.ServicePointId, ct);
+            var waiting = await _queueEntries.GetWaitingByServicePointAsync(entry.ServicePointId, ct);
+
+            return new QueueSnapshotDto
+            {
+                Current = current is null ? null : new QueueEntryDto
+                {
+                    Id = current.Id,
+                    TicketNo = current.TicketNo,
+                    Status = current.Status.ToString(),
+                    Priority = current.Priority,
+                    CreatedAt = current.CreatedAt
+                },
+                Waiting = waiting.Select(w => new QueueEntryDto
+                {
+                    Id = w.Id,
+                    TicketNo = w.TicketNo,
+                    Status = w.Status.ToString(),
+                    Priority = w.Priority,
+                    CreatedAt = w.CreatedAt
+                }).ToList()
+            };
+        }
+
+        private string GenerateTicketNumber(Reservation reservation)
+        {
+            var timePart = _clock.UtcNow.ToString("yyyyMMddHHmmss");
+            var prefix = reservation.ServicePointId.ToString("N").Substring(0, 4).ToUpperInvariant();
+            return $"{prefix}-{timePart}";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add CheckInByQrCommand definition returning queue snapshot data
- implement command handler to validate reservations, prevent duplicate queue entries, and enqueue with generated ticket numbers
- trigger realtime queue updates and return the updated snapshot after check-in

## Testing
- `dotnet test QLine.sln` *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69476825bd8c8320a1aae4752c993c48)