### PR TITLE
Add QR codes for reservations and kiosk self check-in

### DIFF
--- a/QLine.Web/Components/Layout/EmptyLayout.razor
+++ b/QLine.Web/Components/Layout/EmptyLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/QLine.Web/Components/Pages/Kiosk/SelfCheckIn.razor
+++ b/QLine.Web/Components/Pages/Kiosk/SelfCheckIn.razor
@@ -1,0 +1,170 @@
+@page "/kiosk"
+@layout Layout.EmptyLayout
+@using MediatR
+@using QLine.Application.DTO
+@using QLine.Application.Features.Reservations.Commands
+@using System.Linq
+@inject IMediator Mediator
+
+<div class="kiosk-screen">
+    <div class="kiosk-panel">
+        @if (_checkInSuccessful)
+        {
+            <div class="status success">
+                <h1>Welcome!</h1>
+                <p class="ticket">Your Ticket Number: @_ticketNumber</p>
+                <button class="btn primary" @onclick="Reset">Next Client</button>
+            </div>
+        }
+        else
+        {
+            <div class="status ready">
+                <h1>Self-Service Kiosk</h1>
+                <p class="helper">Please scan or paste your Reservation ID to check in.</p>
+
+                @if (!string.IsNullOrWhiteSpace(_errorMessage))
+                {
+                    <div class="alert">@_errorMessage</div>
+                }
+
+                <form class="scan-form" @onsubmit="HandleSubmit" @onsubmit:preventDefault>
+                    <input type="text"
+                           placeholder="Reservation ID"
+                           @bind="_scanInput"
+                           class="scan-input"
+                           autocomplete="off"
+                           aria-label="Reservation ID"
+                           required />
+                    <button class="btn primary" type="submit" disabled="@_isProcessing">Check In</button>
+                </form>
+            </div>
+        }
+    </div>
+</div>
+
+<style>
+    .kiosk-screen {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f5f7fa;
+        padding: 24px;
+    }
+
+    .kiosk-panel {
+        width: 100%;
+        max-width: 520px;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+        padding: 32px;
+        text-align: center;
+    }
+
+    .status h1 {
+        margin-bottom: 12px;
+    }
+
+    .helper {
+        color: #555;
+        margin-bottom: 20px;
+    }
+
+    .scan-form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .scan-input {
+        font-size: 1.2rem;
+        padding: 12px 16px;
+        border-radius: 8px;
+        border: 1px solid #ccc;
+    }
+
+    .btn {
+        padding: 12px 16px;
+        border: none;
+        border-radius: 8px;
+        font-size: 1rem;
+        cursor: pointer;
+    }
+
+    .btn.primary {
+        background-color: #2d8fdd;
+        color: #fff;
+    }
+
+    .btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+
+    .alert {
+        background: #ffe5e5;
+        color: #b20000;
+        padding: 10px 12px;
+        border-radius: 8px;
+        margin-bottom: 12px;
+    }
+
+    .status.success {
+        color: #0a7a2c;
+    }
+
+    .ticket {
+        font-size: 1.5rem;
+        margin: 16px 0;
+        font-weight: bold;
+    }
+</style>
+
+@code {
+    private string _scanInput = string.Empty;
+    private bool _isProcessing;
+    private bool _checkInSuccessful;
+    private string _ticketNumber = "Issued";
+    private string? _errorMessage;
+
+    private async Task HandleSubmit()
+    {
+        _errorMessage = null;
+
+        if (!Guid.TryParse(_scanInput, out var reservationId))
+        {
+            _errorMessage = "Invalid code. Please enter a valid Reservation ID.";
+            return;
+        }
+
+        _isProcessing = true;
+
+        try
+        {
+            var snapshot = await Mediator.Send(new CheckInByQrCommand(reservationId));
+            var ticket = snapshot.Waiting
+                .OrderByDescending(w => w.CreatedAt)
+                .FirstOrDefault() ?? snapshot.Current;
+
+            _ticketNumber = ticket?.TicketNo ?? "Issued";
+            _checkInSuccessful = true;
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        finally
+        {
+            _isProcessing = false;
+        }
+    }
+
+    private void Reset()
+    {
+        _checkInSuccessful = false;
+        _scanInput = string.Empty;
+        _ticketNumber = "Issued";
+        _errorMessage = null;
+    }
+}

--- a/QLine.Web/Components/Pages/Reserve.razor
+++ b/QLine.Web/Components/Pages/Reserve.razor
@@ -6,6 +6,7 @@
 @using QLine.Application.Features.Reservations.Commands
 @using QLine.Application.Features.Reservations.Queries
 @using QLine.Application.DTO
+@using QRCoder
 @inject IMediator Mediator
 
 <h3>Create Reservation</h3>
@@ -62,6 +63,15 @@ else
         <p><strong>Ticket:</strong>@_created.TicketNo</p>
         <p><strong>Start (local):</strong><UtcDate Value="@_created.StartTime" /></p>
         <p><small>UTC: @_created.StartTime.ToString("u")</small></p>
+
+        @if (!string.IsNullOrEmpty(_qrCodeBase64))
+        {
+                <div class="qr-wrapper">
+                        <img src="data:image/png;base64,@_qrCodeBase64" alt="Reservation QR Code" class="qr-image" />
+                        <p class="qr-helper">Please scan this code at the kiosk upon arrival.</p>
+                        <p class="qr-helper"><strong>Reservation ID for manual entry:</strong> @_created?.Id</p>
+                </div>
+        }
 }
 
 <style>
@@ -70,6 +80,25 @@ else
                 grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
                 gap: 8px;
                 margin-top: 8px;
+        }
+
+        .qr-wrapper {
+                margin-top: 16px;
+                padding: 12px;
+                border: 1px solid #ddd;
+                border-radius: 8px;
+                max-width: 320px;
+        }
+
+        .qr-image {
+                display: block;
+                width: 100%;
+                height: auto;
+        }
+
+        .qr-helper {
+                margin-top: 8px;
+                margin-bottom: 0;
         }
 </style>
 
@@ -84,6 +113,7 @@ else
         private ReservationDto? _created;
         private string? _errorMessage;
         private List<string>? _errorDetails;
+        private string? _qrCodeBase64;
 
         protected override async Task OnInitializedAsync()
         {
@@ -137,6 +167,7 @@ else
                 {
                         _errorMessage = null;
                         _errorDetails = null;
+                        _qrCodeBase64 = null;
                         if (_selectedSlot is null || !_selectedSlot.IsAvailable)
                         {
                                 _errorMessage = "Please select an available time slot.";
@@ -152,10 +183,20 @@ else
                         ));
 
                         _created = dto;
+                        _qrCodeBase64 = GenerateQrCode(dto.Id);
                 }
                 catch (Exception ex)
                 {
                         (_errorMessage, _errorDetails) = ex.ToUserMessage();
                 }
+        }
+
+        private string GenerateQrCode(Guid reservationId)
+        {
+                using var generator = new QRCodeGenerator();
+                using var qrCodeData = generator.CreateQrCode(reservationId.ToString(), QRCodeGenerator.ECCLevel.Q);
+                var qrCode = new PngByteQRCode(qrCodeData);
+                var qrCodeBytes = qrCode.GetGraphic(20);
+                return Convert.ToBase64String(qrCodeBytes);
         }
 }

--- a/QLine.Web/QLine.Web.csproj
+++ b/QLine.Web/QLine.Web.csproj
@@ -18,12 +18,13 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="MudBlazor" Version="8.11.0" />
-		<PackageReference Include="MudBlazor.ThemeManager" Version="3.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-	</ItemGroup>
+                <PackageReference Include="MudBlazor" Version="8.11.0" />
+                <PackageReference Include="MudBlazor.ThemeManager" Version="3.0.0" />
+                <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                <PackageReference Include="QRCoder" Version="1.4.3" />
+                <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+                <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="Localization\" />


### PR DESCRIPTION
## Summary
- generate QR codes for reservation confirmations using QRCoder
- add a minimal empty layout and standalone kiosk self check-in page
- process QR-based check-in requests and display ticket details or errors

## Testing
- not run (environment missing dotnet CLI)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948350426b48320bcfce585b1f1d1aa)