### PR TITLE
Remove MaxPerDay from services

### DIFF
--- a/QLine.Application/DTO/ServiceDto.cs
+++ b/QLine.Application/DTO/ServiceDto.cs
@@ -12,6 +12,5 @@ namespace QLine.Application.DTO
         public string Name { get; init; } = default!;
         public int DurationMin { get; init; }
         public int BufferMin { get; init; }
-        public int MaxPerDay { get; init; }
     }
 }

--- a/QLine.Application/Features/Admin/Queries/GetServicesForServicePointQueryHandler.cs
+++ b/QLine.Application/Features/Admin/Queries/GetServicesForServicePointQueryHandler.cs
@@ -27,8 +27,7 @@ namespace QLine.Application.Features.Admin.Queries
                     Id = s.Id,
                     Name = s.Name,
                     DurationMin = s.DurationMin,
-                    BufferMin = s.BufferMin,
-                    MaxPerDay = s.MaxPerDay
+                    BufferMin = s.BufferMin
                 })
                 .ToList();
         }

--- a/QLine.Application/Features/Admin/Services/Commands/UpsertServiceCommand.cs
+++ b/QLine.Application/Features/Admin/Services/Commands/UpsertServiceCommand.cs
@@ -13,7 +13,6 @@ namespace QLine.Application.Features.Admin.Services.Commands
         Guid ServicePointId,
         string Name,
         int DurationMin,
-        int BufferMin,
-        int MaxPerDay
+        int BufferMin
     ) : IRequest<ServiceDto>;
 }

--- a/QLine.Application/Features/Admin/Services/Commands/UpsertServiceCommandHandler.cs
+++ b/QLine.Application/Features/Admin/Services/Commands/UpsertServiceCommandHandler.cs
@@ -33,8 +33,7 @@ namespace QLine.Application.Features.Admin.Services.Commands
                     request.ServicePointId,
                     request.Name,
                     request.DurationMin,
-                    request.BufferMin,
-                    request.MaxPerDay
+                    request.BufferMin
                 );
                 await _repo.AddAsync(svc, ct);
 
@@ -46,7 +45,6 @@ namespace QLine.Application.Features.Admin.Services.Commands
                     Name = svc.Name,
                     DurationMin = svc.DurationMin,
                     BufferMin = svc.BufferMin,
-                    MaxPerDay = svc.MaxPerDay,
                 };
             }
             else
@@ -54,7 +52,7 @@ namespace QLine.Application.Features.Admin.Services.Commands
                 var existing = await _repo.GetByIdAsync(request.Id!.Value, ct)
                     ?? throw new DomainException("Service not found.");
 
-                existing.Update(request.Name, request.DurationMin, request.BufferMin, request.MaxPerDay);
+                existing.Update(request.Name, request.DurationMin, request.BufferMin);
 
                 await _repo.UpdateAsync(existing, ct);
                 await _realtime.QueueUpdated(request.ServicePointId, ct);
@@ -65,7 +63,6 @@ namespace QLine.Application.Features.Admin.Services.Commands
                     Name = existing.Name,
                     DurationMin = existing.DurationMin,
                     BufferMin = existing.BufferMin,
-                    MaxPerDay = existing.MaxPerDay,
                 };
             }
         }

--- a/QLine.Application/Validation/UpsertServiceCommandValidator.cs
+++ b/QLine.Application/Validation/UpsertServiceCommandValidator.cs
@@ -16,7 +16,6 @@ namespace QLine.Application.Validation
             RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
             RuleFor(x => x.DurationMin).GreaterThan(0);
             RuleFor(x => x.BufferMin).GreaterThanOrEqualTo(0);
-            RuleFor(x => x.MaxPerDay).GreaterThanOrEqualTo(0);
         }
     }
 }

--- a/QLine.Domain/Entities/Service.cs
+++ b/QLine.Domain/Entities/Service.cs
@@ -15,18 +15,16 @@ namespace QLine.Domain.Entities
         public string Name { get; private set; } = null!;
         public int DurationMin { get; private set; }
         public int BufferMin {  get; private set; }
-        public int MaxPerDay { get; private set; }
 
         public Service() { }
 
-        private Service(Guid id, Guid servicePointId, string name, int durationMin, int bufferMin, int maxPerDay)
+        private Service(Guid id, Guid servicePointId, string name, int durationMin, int bufferMin)
         {
             if (id == Guid.Empty) throw new DomainException("Service Id cannot be empty.");
             if (servicePointId == Guid.Empty) throw new DomainException("Service ServicePointId cannot be empty.");
             if (string.IsNullOrWhiteSpace(name)) throw new DomainException("Service Name is required.");
             if (durationMin <= 0) throw new DomainException("Service Duration must be positive.");
             if (bufferMin < 0) throw new DomainException("Service Buffer cannot be negative.");
-            if (maxPerDay < 0) throw new DomainException("Service MaxPerDay cannot be negative.");
 
 
             Id = id;
@@ -34,23 +32,20 @@ namespace QLine.Domain.Entities
             Name = name.Trim();
             DurationMin = durationMin;
             BufferMin = bufferMin;
-            MaxPerDay = maxPerDay;
         }
 
-        public static Service Create(Guid id, Guid servicePointId, string name, int durationMin, int bufferMin, int maxPerDay)
-            => new(id, servicePointId, name, durationMin, bufferMin, maxPerDay);
+        public static Service Create(Guid id, Guid servicePointId, string name, int durationMin, int bufferMin)
+            => new(id, servicePointId, name, durationMin, bufferMin);
 
-        public void Update(string name, int durationMin, int bufferMin, int maxPerDay)
+        public void Update(string name, int durationMin, int bufferMin)
         {
             if (string.IsNullOrWhiteSpace(name)) throw new DomainException("Service Name is required.");
             if (durationMin <= 0) throw new DomainException("Service Duration must be positive.");
             if (bufferMin < 0) throw new DomainException("Service Buffer cannot be negative.");
-            if (maxPerDay < 0) throw new DomainException("Service MaxPerDay cannot be negative.");
 
             Name = name.Trim();
             DurationMin = durationMin;
             BufferMin = bufferMin;
-            MaxPerDay = maxPerDay;
         }
     }
 }

--- a/QLine.Infrastructure/Migrations/20251220201456_InitialCreate.Designer.cs
+++ b/QLine.Infrastructure/Migrations/20251220201456_InitialCreate.Designer.cs
@@ -148,9 +148,6 @@ namespace QLine.Infrastructure.Migrations
                     b.Property<int>("DurationMin")
                         .HasColumnType("integer");
 
-                    b.Property<int>("MaxPerDay")
-                        .HasColumnType("integer");
-
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)

--- a/QLine.Infrastructure/Migrations/20251220201456_InitialCreate.cs
+++ b/QLine.Infrastructure/Migrations/20251220201456_InitialCreate.cs
@@ -66,8 +66,7 @@ namespace QLine.Infrastructure.Migrations
                     ServicePointId = table.Column<Guid>(type: "uuid", nullable: false),
                     Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     DurationMin = table.Column<int>(type: "integer", nullable: false),
-                    BufferMin = table.Column<int>(type: "integer", nullable: false),
-                    MaxPerDay = table.Column<int>(type: "integer", nullable: false)
+                    BufferMin = table.Column<int>(type: "integer", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/QLine.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/QLine.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -145,9 +145,6 @@ namespace QLine.Infrastructure.Migrations
                     b.Property<int>("DurationMin")
                         .HasColumnType("integer");
 
-                    b.Property<int>("MaxPerDay")
-                        .HasColumnType("integer");
-
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)

--- a/QLine.Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
+++ b/QLine.Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
@@ -19,7 +19,6 @@ namespace QLine.Infrastructure.Persistence.Configurations
             b.Property(x => x.Name).IsRequired().HasMaxLength(200);
             b.Property(x => x.DurationMin).IsRequired();
             b.Property(x => x.BufferMin).IsRequired();
-            b.Property(x => x.MaxPerDay).IsRequired();
 
             b.HasIndex(x => new { x.ServicePointId, x.Name });
         }

--- a/QLine.Web/Components/Pages/Admin/Services.razor
+++ b/QLine.Web/Components/Pages/Admin/Services.razor
@@ -12,30 +12,29 @@
 <p><a href="/admin/servicepoints">Back to Service Points</a></p>
 
 <div style="margin-bottom:12px; padding:10px; border:1px solid #eee; border-radius: 6px;">
-	<h4>@(_editingId is null ? "Create" : "Edit")</h4>
-	<div><label>Name</label><br /><input @bind="_name" /></div>
-	<div><label>Duration (min)</label><br /><input type="number" @bind="_dur" /></div>
-	<div><label>Buffer (min)</label><br /><input type="number" @bind="_buf" /></div>
-	<div><label>Max per day</label><br /><input type="number" @bind="_max" /></div>
-	<button @onclick="SaveAsync">Save</button>
-	@if (_editingId is not null)
-	{
-		<button @onclick="CancelEdit" style="margin-left:6px;">Cancel</button>
-	}
+        <h4>@(_editingId is null ? "Create" : "Edit")</h4>
+        <div><label>Name</label><br /><input @bind="_name" /></div>
+        <div><label>Duration (min)</label><br /><input type="number" @bind="_dur" /></div>
+        <div><label>Buffer (min)</label><br /><input type="number" @bind="_buf" /></div>
+        <button @onclick="SaveAsync">Save</button>
+        @if (_editingId is not null)
+        {
+                <button @onclick="CancelEdit" style="margin-left:6px;">Cancel</button>
+        }
 </div>
 
 <table>
-	<thead>
-		<tr><th>Name</th><th>Duration</th><th>Buffer</th><th>Max/day</th><th></th></tr>
-	</thead>
-	<tbody>
-		@foreach (var s in _list)
-		{
-			<tr>
-				<td>@s.Name</td><td>@s.DurationMin</td><td>@s.BufferMin</td><td>@s.MaxPerDay</td>
-				<td>
-					<button @onclick="() => Edit(s)">Edit</button>
-					<button @onclick="() => DeleteAsync(s.Id)" style="margin-left:6px;">Delete</button>
+        <thead>
+                <tr><th>Name</th><th>Duration</th><th>Buffer</th><th></th></tr>
+        </thead>
+        <tbody>
+                @foreach (var s in _list)
+                {
+                        <tr>
+                                <td>@s.Name</td><td>@s.DurationMin</td><td>@s.BufferMin</td>
+                                <td>
+                                        <button @onclick="() => Edit(s)">Edit</button>
+                                        <button @onclick="() => DeleteAsync(s.Id)" style="margin-left:6px;">Delete</button>
 				</td>
 			</tr>
 		}
@@ -45,36 +44,33 @@
 @code {
     [Parameter] public Guid ServicePointId { get; set; }
 
-    private List<ServiceDto> _list = new();
+        private List<ServiceDto> _list = new();
 
-	private Guid? _editingId;
-	private string _name = "";
-	private int _dur = 15;
-	private int _buf = 5;
-	private int _max = 100;
+        private Guid? _editingId;
+        private string _name = "";
+        private int _dur = 15;
+        private int _buf = 5;
 
 	protected override async Task OnInitializedAsync() => await LoadAsync();
 
 	private async Task LoadAsync()
 		=> _list = (await Mediator.Send(new GetServicesForServicePointQuery(ServicePointId))).ToList();
 
-	private void Edit(ServiceDto s)
-	{
-		_editingId = s.Id;
-		_name = s.Name;
-		_dur = s.DurationMin;
-		_buf = s.BufferMin;
-		_max = s.MaxPerDay;
-	}
+        private void Edit(ServiceDto s)
+        {
+                _editingId = s.Id;
+                _name = s.Name;
+                _dur = s.DurationMin;
+                _buf = s.BufferMin;
+        }
 
-	private void CancelEdit()
-	{
-		_editingId = null;
-		_name = "";
-		_dur = 15;
-		_buf = 5;
-		_max = 100;
-	}
+        private void CancelEdit()
+        {
+                _editingId = null;
+                _name = "";
+                _dur = 15;
+                _buf = 5;
+        }
 
         private async Task SaveAsync()
         {
@@ -83,11 +79,10 @@
                         ServicePointId: ServicePointId,
                         Name: _name,
                         DurationMin: _dur,
-			BufferMin: _buf,
-			MaxPerDay: _max
-		));
-		CancelEdit();
-		await LoadAsync();
+                        BufferMin: _buf
+                ));
+                CancelEdit();
+                await LoadAsync();
 		StateHasChanged();
 	}
 


### PR DESCRIPTION
## Summary
- remove the obsolete MaxPerDay field from Service domain, application DTOs, and admin UI
- update EF Core configuration and migrations so Services no longer include the MaxPerDay column

## Testing
- Not run (dotnet SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484259ffb48320be38ffc568c643c6)