### PR TITLE
Add reservation rescheduling support

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/RescheduleReservationCommand.cs
+++ b/QLine.Application/Features/Reservations/Commands/RescheduleReservationCommand.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
-    public class RescheduleReservationCommand
-    {
-    }
+    public sealed record RescheduleReservationCommand(
+        Guid ReservationId,
+        DateTimeOffset NewStartTime
+    ) : IRequest<ReservationDto>;
 }

--- a/QLine.Application/Features/Reservations/Commands/RescheduleReservationCommandHandler.cs
+++ b/QLine.Application/Features/Reservations/Commands/RescheduleReservationCommandHandler.cs
@@ -1,12 +1,65 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.Abstractions;
+using QLine.Application.DTO;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
-    public class RescheduleReservationCommandHandler
+    public sealed class RescheduleReservationCommandHandler
+        : IRequestHandler<RescheduleReservationCommand, ReservationDto>
     {
+        private readonly IReservationRepository _reservations;
+        private readonly IDateTimeProvider _clock;
+        private readonly ICurrentUser _currentUser;
+
+        public RescheduleReservationCommandHandler(
+            IReservationRepository reservations,
+            IDateTimeProvider clock,
+            ICurrentUser currentUser)
+        {
+            _reservations = reservations;
+            _clock = clock;
+            _currentUser = currentUser;
+        }
+
+        public async Task<ReservationDto> Handle(RescheduleReservationCommand request, CancellationToken ct)
+        {
+            var userId = _currentUser.UserId ?? throw new UnauthorizedAccessException();
+
+            var reservation = await _reservations.GetByIdAsync(request.ReservationId, ct)
+                ?? throw new DomainException("Reservation not found.");
+
+            if (reservation.UserId != userId)
+                throw new UnauthorizedAccessException();
+
+            var safeStartTime = request.NewStartTime.ToUniversalTime();
+
+            if (safeStartTime < _clock.UtcNow.AddMinutes(-1))
+            {
+                throw new DomainException("Cannot reschedule a reservation to the past.");
+            }
+
+            if (reservation.StartTime != safeStartTime)
+            {
+                var slotFree = await _reservations.IsSlotAvailableAsync(reservation.ServicePointId, safeStartTime, ct);
+
+                if (!slotFree)
+                    throw new DomainException("The selected slot is already occupied.");
+            }
+
+            reservation.Reschedule(safeStartTime);
+            await _reservations.UpdateAsync(reservation, ct);
+
+            return new ReservationDto
+            {
+                Id = reservation.Id,
+                ServicePointId = reservation.ServicePointId,
+                ServiceId = reservation.ServiceId,
+                UserId = reservation.UserId,
+                StartTime = reservation.StartTime,
+                Status = reservation.Status.ToString()
+            };
+        }
     }
 }

--- a/QLine.Web/Components/Pages/Reserve.razor
+++ b/QLine.Web/Components/Pages/Reserve.razor
@@ -1,6 +1,7 @@
 @page "/reserve/{ServicePointId:guid}/{ServiceId:guid}"
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using MediatR
 @using QLine.Application.Features.Reservations.Commands
@@ -13,7 +14,7 @@
 
 @if (_created is null)
 {
-        <EditForm Model="this" OnValidSubmit="CreateAsync">
+        <EditForm Model="this" OnValidSubmit="SubmitAsync">
                 <DataAnnotationsValidator />
                 <div>
                     <label>Date (local): </label>
@@ -48,7 +49,7 @@
                         }
                 </div>
                 <div style="margin-top:8px;">
-                        <button type="submit" disabled="@(_selectedSlot is null)">Create</button>
+                        <button type="submit" disabled="@(_selectedSlot is null)">@(_isReschedule ? "Reschedule" : "Create")</button>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(_errorMessage))
                 {
@@ -58,8 +59,15 @@
 }
 else
 {
-        <h4>Reservation created</h4>
+        <h4>@(_isReschedule ? "Reservation Rescheduled" : "Reservation created")</h4>
         <p><strong>Start:</strong><UtcDate Value="@_created.StartTime" /></p>
+
+        @if (_isReschedule)
+        {
+                <p>
+                        <a href="/profile">Back to profile</a>
+                </p>
+        }
 
         @if (!string.IsNullOrEmpty(_qrCodeBase64))
         {
@@ -74,6 +82,7 @@ else
 @code {
         [Parameter] public Guid ServicePointId { get; set; }
         [Parameter] public Guid ServiceId { get; set; }
+        [Parameter, SupplyParameterFromQuery] public Guid? RescheduleId { get; set; }
 
         private DateTime _selectedDate = DateTime.Today;
         private List<SlotDto> _availableSlots = new();
@@ -83,6 +92,7 @@ else
         private string? _errorMessage;
         private List<string>? _errorDetails;
         private string? _qrCodeBase64;
+        private bool _isReschedule => RescheduleId.HasValue;
 
         protected override async Task OnInitializedAsync()
         {
@@ -130,7 +140,7 @@ else
                 _selectedSlot = slot;
         }
 
-        private async Task CreateAsync()
+        private async Task SubmitAsync()
         {
                 try
                 {
@@ -145,14 +155,25 @@ else
 
                         var startLocal = DateTime.SpecifyKind(_selectedDate.Date + _selectedSlot.Start, DateTimeKind.Local);
 
-                        var dto = await Mediator.Send(new CreateReservationCommand(
-                                ServicePointId: ServicePointId,
-                                ServiceId: ServiceId,
-                                StartTime: new DateTimeOffset(startLocal.ToUniversalTime())
-                        ));
+                        var startTime = new DateTimeOffset(startLocal.ToUniversalTime());
 
-                        _created = dto;
-                        _qrCodeBase64 = GenerateQrCode(dto.Id);
+                        if (_isReschedule)
+                        {
+                                _created = await Mediator.Send(new RescheduleReservationCommand(
+                                        ReservationId: RescheduleId!.Value,
+                                        NewStartTime: startTime));
+                        }
+                        else
+                        {
+                                var dto = await Mediator.Send(new CreateReservationCommand(
+                                        ServicePointId: ServicePointId,
+                                        ServiceId: ServiceId,
+                                        StartTime: startTime
+                                ));
+
+                                _created = dto;
+                                _qrCodeBase64 = GenerateQrCode(dto.Id);
+                        }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- add query-driven reschedule mode to the reservation page with updated submit behavior and messaging
- introduce a reschedule reservation command and handler to update reservation times securely

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948952fbaa48320b3f0012d148157c8)