### PR TITLE
Validate reservation ownership and slot availability

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/CancelReservationCommandHandler.cs
+++ b/QLine.Application/Features/Reservations/Commands/CancelReservationCommandHandler.cs
@@ -2,6 +2,7 @@ using MediatR;
 using QLine.Application.Abstractions;
 using QLine.Domain;
 using QLine.Domain.Abstractions;
+using QLine.Domain.Enums;
 
 namespace QLine.Application.Features.Reservations.Commands
 {
@@ -28,8 +29,8 @@ namespace QLine.Application.Features.Reservations.Commands
             if (reservation.UserId != userId)
                 throw new UnauthorizedAccessException();
 
-            if (reservation.Status == Domain.Enums.ReservationStatus.Cancelled)
-                return;
+            if (reservation.Status != ReservationStatus.Active)
+                throw new DomainException("Reservation is not active.");
 
             reservation.Cancel();
             await _reservations.UpdateAsync(reservation, ct);

--- a/QLine.Domain/Abstractions/IReservationRepository.cs
+++ b/QLine.Domain/Abstractions/IReservationRepository.cs
@@ -13,7 +13,11 @@ namespace QLine.Domain.Abstractions
         /// Checking slot availability, taking into account active reservations.
         /// </summary>
 
-        Task<bool> IsSlotAvailableAsync(Guid servicePointId, DateTimeOffset startTime, CancellationToken ct);
+        Task<bool> IsSlotAvailableAsync(
+            Guid servicePointId,
+            DateTimeOffset startTime,
+            CancellationToken ct,
+            Guid? reservationIdToIgnore = null);
 
         Task<IReadOnlyList<Reservation>> GetByDayAsync(
             Guid servicePointId,

--- a/QLine.Infrastructure/Persistence/Repositories/ReservationRepository.cs
+++ b/QLine.Infrastructure/Persistence/Repositories/ReservationRepository.cs
@@ -15,12 +15,17 @@ namespace QLine.Infrastructure.Persistence.Repositories
         private readonly AppDbContext _db;
         public ReservationRepository(AppDbContext db) => _db = db;
 
-        public async Task<bool> IsSlotAvailableAsync(Guid servicePointId, DateTimeOffset startTime, CancellationToken ct)
+        public async Task<bool> IsSlotAvailableAsync(
+            Guid servicePointId,
+            DateTimeOffset startTime,
+            CancellationToken ct,
+            Guid? reservationIdToIgnore = null)
         {
             var isTaken = await _db.Reservations.AsNoTracking()
                 .AnyAsync(r => r.ServicePointId == servicePointId
                             && r.StartTime == startTime
-                            && r.Status == ReservationStatus.Active, ct);
+                            && r.Status == ReservationStatus.Active
+                            && (reservationIdToIgnore == null || r.Id != reservationIdToIgnore), ct);
 
             return !isTaken;
         }


### PR DESCRIPTION
## Summary
- enforce active-status checks and ownership validation when canceling or rescheduling reservations
- allow slot availability checks to ignore the reservation being modified and persist updates
- return up-to-date reservation data from the reschedule handler

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948976011f88320b0c59c943adf5cbf)