### PR TITLE
Update reservation status display from queue entries

### DIFF
--- a/QLine.Application/Features/Reservations/Queries/GetMyReservationsQueryHandler.cs
+++ b/QLine.Application/Features/Reservations/Queries/GetMyReservationsQueryHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediatR;
 using QLine.Application.DTO;
 using QLine.Domain.Abstractions;
+using QLine.Domain.Enums;
 
 namespace QLine.Application.Features.Reservations.Queries
 {
@@ -32,6 +33,16 @@ namespace QLine.Application.Features.Reservations.Queries
             {
                 var entry = await _queueEntries.GetByReservationAsync(r.Id, ct);
 
+                var status = entry?.Status switch
+                {
+                    QueueStatus.Waiting => QueueStatus.Waiting.ToString(),
+                    QueueStatus.InService => QueueStatus.Waiting.ToString(),
+                    QueueStatus.Skipped => QueueStatus.Waiting.ToString(),
+                    QueueStatus.Done => ReservationStatus.Completed.ToString(),
+                    QueueStatus.NoShow => QueueStatus.NoShow.ToString(),
+                    _ => r.Status.ToString()
+                };
+
                 result.Add(new ReservationDto
                 {
                     Id = r.Id,
@@ -39,7 +50,7 @@ namespace QLine.Application.Features.Reservations.Queries
                     ServiceId = r.ServiceId,
                     UserId = r.UserId,
                     StartTime = r.StartTime,
-                    Status = r.Status.ToString(),
+                    Status = status,
                     TicketNo = entry?.TicketNo
                 });
             }

--- a/QLine.Web/Components/Pages/Profile.razor
+++ b/QLine.Web/Components/Pages/Profile.razor
@@ -109,6 +109,10 @@ else
                             <p class="card-text">
                                 <strong>Ticket:</strong> <span class="badge bg-secondary">@(reservation.TicketNo ?? "-")</span>
                             </p>
+                            <p class="card-text mb-0">
+                                <strong>Reservation ID:</strong>
+                                <span class="text-monospace">@reservation.Id</span>
+                            </p>
 
                             <div class="btn-group mt-2">
                                 <button class="btn btn-outline-primary btn-sm" @onclick="() => ToggleQrCode(reservation.Id)">


### PR DESCRIPTION
## Summary
- derive profile reservation statuses from queue entries so check-ins and completions show correctly
- surface reservation IDs in the profile alongside QR codes

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a53c827c8320ac0e54a983f8663b)