### PR TITLE
Add SignalR realtime updates to profile page

### DIFF
--- a/QLine.Web/Components/Pages/Profile.razor
+++ b/QLine.Web/Components/Pages/Profile.razor
@@ -2,6 +2,7 @@
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
+@implements IAsyncDisposable
 @using QLine.Domain.Abstractions
 @using QLine.Domain.Entities
 @using QLine.Application.Features.Admin.Queries
@@ -10,6 +11,8 @@
 @using MediatR
 @using QRCoder
 @using System.Web
+@using System.Threading
+@using System.Threading.Tasks
 @using QLine.Application.Abstractions
 @inject IAppUserRepository Users
 @inject ICurrentUser CurrentUser
@@ -207,13 +210,18 @@ else
     private List<ReservationViewModel> _reservations = new();
     private bool _loadingReservations;
     private Guid? _qrReservationId;
+    private IJSObjectReference? _realtimeHandle;
+    private DotNetObjectReference<Profile>? _dotNetRef;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private bool _refreshPending;
+    private HashSet<Guid> _subscribedServicePoints = new();
 
     protected override async Task OnInitializedAsync()
     {
         if (CurrentUser.UserId is Guid userId)
         {
             _user = await Users.GetByIdAsync(userId, CancellationToken.None);
-            await LoadReservations(userId);
+            await RefreshReservationsAsync();
         }
 
         ParseMessages();
@@ -270,6 +278,34 @@ else
 
     private void HideDeleteDialog() => _showDeleteDialog = false;
 
+    private async Task RefreshReservationsAsync()
+    {
+        if (CurrentUser.UserId is not Guid userId)
+        {
+            return;
+        }
+
+        if (!await _refreshGate.WaitAsync(0))
+        {
+            _refreshPending = true;
+            return;
+        }
+
+        try
+        {
+            do
+            {
+                _refreshPending = false;
+                await LoadReservations(userId);
+                await EnsureRealtimeSubscriptionsAsync();
+            } while (_refreshPending);
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
     private async Task LoadReservations(Guid userId)
     {
         _loadingReservations = true;
@@ -306,6 +342,8 @@ else
             .ToList();
 
         _loadingReservations = false;
+
+        await InvokeAsync(StateHasChanged);
     }
 
     private IEnumerable<ReservationViewModel> UpcomingReservations => _reservations
@@ -376,6 +414,61 @@ else
         using var qrCode = new PngByteQRCode(qrCodeData);
         var bytes = qrCode.GetGraphic(20);
         return $"data:image/png;base64,{Convert.ToBase64String(bytes)}";
+    }
+
+    private async Task EnsureRealtimeSubscriptionsAsync()
+    {
+        var servicePointIds = _reservations
+            .Select(r => r.ServicePointId)
+            .Distinct()
+            .ToList();
+
+        var desired = servicePointIds.ToHashSet();
+
+        if (_realtimeHandle is null)
+        {
+            if (desired.Count == 0)
+            {
+                return;
+            }
+
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            _realtimeHandle = await Js.InvokeAsync<IJSObjectReference>(
+                "qlineRealtime.connectToServicePoints",
+                servicePointIds,
+                _dotNetRef);
+
+            _subscribedServicePoints = desired;
+            return;
+        }
+
+        if (desired.Count == 0)
+        {
+            await _realtimeHandle.InvokeVoidAsync("dispose");
+            _realtimeHandle = null;
+            _subscribedServicePoints.Clear();
+            return;
+        }
+
+        if (!_subscribedServicePoints.SetEquals(desired))
+        {
+            await _realtimeHandle.InvokeVoidAsync("updateServicePoints", servicePointIds);
+            _subscribedServicePoints = desired;
+        }
+    }
+
+    [JSInvokable]
+    public Task OnQueueUpdated() => RefreshReservationsAsync();
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_realtimeHandle is not null)
+        {
+            await _realtimeHandle.InvokeVoidAsync("dispose");
+        }
+
+        _dotNetRef?.Dispose();
+        _refreshGate.Dispose();
     }
 
     private sealed class ReservationViewModel

--- a/QLine.Web/wwwroot/js/realtime.js
+++ b/QLine.Web/wwwroot/js/realtime.js
@@ -20,5 +20,48 @@ window.qlineRealtime = {
                     .finally(() => conn.stop());
             }
         };
+    },
+
+    connectToServicePoints: function (servicePointIds, dotNetRef) {
+        const conn = new signalR.HubConnectionBuilder()
+            .withUrl("/hubs/queue")
+            .withAutomaticReconnect()
+            .build();
+
+        let joined = new Set();
+
+        const normalize = (ids) => new Set((ids || []).map(id => id?.toString?.() ?? id));
+
+        const syncGroups = (ids) => {
+            const desired = normalize(ids);
+
+            for (const id of joined) {
+                if (!desired.has(id)) {
+                    conn.invoke("LeaveServicePoint", id).catch(console.error);
+                }
+            }
+
+            for (const id of desired) {
+                if (!joined.has(id)) {
+                    conn.invoke("JoinServicePoint", id).catch(console.error);
+                }
+            }
+
+            joined = desired;
+        };
+
+        conn.on("queueUpdated", payload => {
+            if (!payload || !joined.has(payload.servicePointId)) return;
+            dotNetRef.invokeMethodAsync("OnQueueUpdated");
+        });
+
+        conn.start()
+            .then(() => syncGroups(servicePointIds))
+            .catch(console.error);
+
+        return {
+            updateServicePoints: (ids) => syncGroups(ids),
+            dispose: () => conn.stop()
+        };
     }
 };


### PR DESCRIPTION
## Summary
- add SignalR-backed refresh flow to keep profile reservations current and render updates
- track service point subscriptions and dispose realtime resources when no longer needed
- extend the SignalR helper to connect to multiple service points at once

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948ae6f9890832083ef01006ea742f7)