### PR TITLE
Refine display board navigation and ticketing

### DIFF
--- a/QLine.Application/Features/Reservations/Commands/CheckInByQrCommandHandler.cs
+++ b/QLine.Application/Features/Reservations/Commands/CheckInByQrCommandHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -98,9 +99,13 @@ namespace QLine.Application.Features.Reservations.Commands
 
         private string GenerateTicketNumber(Reservation reservation)
         {
-            var timePart = _clock.UtcNow.ToString("yyyyMMddHHmmss");
-            var prefix = reservation.ServicePointId.ToString("N").Substring(0, 4).ToUpperInvariant();
-            return $"{prefix}-{timePart}";
+            var prefix = reservation.ServicePointId
+                .ToString("N")
+                .Substring(0, 4)
+                .ToUpperInvariant();
+
+            var randomNumber = RandomNumberGenerator.GetInt32(100, 10000);
+            return $"{prefix}-{randomNumber:0000}";
         }
     }
 }

--- a/QLine.Web/Components/Layout/NavMenu.razor
+++ b/QLine.Web/Components/Layout/NavMenu.razor
@@ -26,11 +26,15 @@
             </NavLink>
         </div>
 
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="display/22222222-2222-2222-2222-222222222222">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Display
-            </NavLink>
-        </div>
+        <AuthorizeView Roles="Staff, Admin">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="display">
+                        <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Displays
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
 
         <AuthorizeView Roles="Staff, Admin">
             <Authorized>

--- a/QLine.Web/Components/Pages/Display.razor
+++ b/QLine.Web/Components/Pages/Display.razor
@@ -1,92 +1,205 @@
-﻿@page "/display/{ServicePointId:guid}"
+@page "/display/{ServicePointId:guid}"
 @using MediatR
 @using Microsoft.JSInterop
 @using QLine.Application.DTO
+@using QLine.Application.Features.Admin.Queries
 @using QLine.Application.Features.Queue.Queries
 @inject IMediator Mediator
 @inject IJSRuntime JS
+@inject NavigationManager Nav
 
-<h3>Now Serving</h3>
+<PageTitle>Display Board</PageTitle>
 
-@if (_snapshot is null)
+@if (_isLoading)
 {
-	<p>Loading...</p>
+    <p>Loading display...</p>
+}
+else if (!string.IsNullOrWhiteSpace(_errorMessage))
+{
+    <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+    <a class="btn btn-outline-primary mt-3" href="/display">Back to display menu</a>
+}
+else if (_snapshot is null)
+{
+    <p>Queue data is unavailable right now.</p>
 }
 else
 {
-	<div style="font-size:56px;font-weight:800;margin:10px 0;">
-		@(_snapshot.Current?.TicketNo ?? "—")
-	</div>
+    <div class="display-board">
+        <section class="now-serving">
+            <div class="section-header">
+                <div>
+                    <div class="section-label">Now Serving</div>
+                    @if (!string.IsNullOrWhiteSpace(_servicePointName))
+                    {
+                        <div class="section-point">@_servicePointName</div>
+                    }
+                </div>
+            </div>
 
-	<div style="margin-top:16px;">
-		<h4>Up next</h4>
-		@if (_snapshot.Waiting.Count == 0)
-		{ 
-			<p>(empty)</p>
-		}
-		else
-		{
-			<ul>
-				@foreach(var w in _snapshot.Waiting.Take(5))
-				{
-					<li style="font-size:24px;">@w.TicketNo</li>
-				}
-			</ul>
-		}
-	</div>
+            @if (_snapshot.Current is null)
+            {
+                <div class="now-serving-placeholder">
+                    <div class="placeholder-text">Please wait</div>
+                </div>
+            }
+            else
+            {
+                <div class="ticket-number">@_snapshot.Current.TicketNo</div>
+            }
+        </section>
+
+        <section class="up-next">
+            <div class="section-header">
+                <div class="section-label">Up Next</div>
+                <div class="section-subtitle">Next clients in line</div>
+            </div>
+
+            @if (_snapshot.Waiting.Count == 0)
+            {
+                <div class="empty">(empty)</div>
+            }
+            else
+            {
+                <ul class="up-next-list">
+                    @foreach (var w in _snapshot.Waiting.Take(5))
+                    {
+                        <li class="up-next-item">@w.TicketNo</li>
+                    }
+                </ul>
+            }
+        </section>
+    </div>
 }
 
 @code {
-	[Parameter] public Guid ServicePointId { get; set; }
+    [Parameter] public Guid ServicePointId { get; set; }
 
-	private readonly SemaphoreSlim _refreshGate = new(1, 1);
-	private bool _refreshPending;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private bool _refreshPending;
 
-	private IJSObjectReference? _realtimeHandle;
-	private QueueSnapshotDto? _snapshot;
+    private IJSObjectReference? _realtimeHandle;
+    private QueueSnapshotDto? _snapshot;
+    private bool _isLoading = true;
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+    private string? _servicePointName;
+    private bool _isFirstRender = true;
+    private string? _lastTicketNo;
 
-	protected override async Task OnInitializedAsync() => await RefreshAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        if (ServicePointId == Guid.Empty)
+        {
+            Nav.NavigateTo("/display", true);
+            return;
+        }
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-		if (firstRender)
-		{
-			_realtimeHandle = await JS.InvokeAsync<IJSObjectReference>(
-				"qlineRealtime.connect", ServicePointId, DotNetObjectReference.Create(this));
+        await LoadServicePointNameAsync();
+        await RefreshAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && ServicePointId != Guid.Empty)
+        {
+            _realtimeHandle = await JS.InvokeAsync<IJSObjectReference>(
+                "qlineRealtime.connect", ServicePointId, DotNetObjectReference.Create(this));
         }
     }
 
-	private async Task RefreshAsync()
-	{
-		if (!Guid.TryParse(ServicePointId.ToString(), out var sp)) return;
+    private async Task LoadServicePointNameAsync()
+    {
+        try
+        {
+            var points = await Mediator.Send(new GetServicePointsQuery());
+            _servicePointName = points.FirstOrDefault(p => p.Id == ServicePointId)?.Name;
+        }
+        catch
+        {
+            _servicePointName = null;
+        }
+    }
 
-		if(!await _refreshGate.WaitAsync(0))
-		{
-			_refreshPending = true;
-			return;
-		}
+    private async Task RefreshAsync()
+    {
+        if (ServicePointId == Guid.Empty)
+        {
+            Nav.NavigateTo("/display", true);
+            return;
+        }
 
-		try 
-		{
-			do
-			{
-				_refreshPending = false;
-				_snapshot = await Mediator.Send(new GetQueueQuery(sp));
-				StateHasChanged();
-			} while (_refreshPending);
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
+        if (!await _refreshGate.WaitAsync(0))
+        {
+            _refreshPending = true;
+            return;
+        }
 
-	[JSInvokable]
-	public async Task OnQueueUpdated() => await RefreshAsync();
+        try
+        {
+            do
+            {
+                _refreshPending = false;
 
-	public async ValueTask DisposeAsync()
-	{
-		if (_realtimeHandle is not null)
-			await _realtimeHandle.InvokeVoidAsync("dispose");
-	}
+                QueueSnapshotDto? snapshot = null;
+                try
+                {
+                    snapshot = await Mediator.Send(new GetQueueQuery(ServicePointId));
+                    _errorMessage = null;
+                    _errorDetails = null;
+                }
+                catch (Exception ex)
+                {
+                    (_errorMessage, _errorDetails) = ex.ToUserMessage();
+                    _snapshot = null;
+                    _isLoading = false;
+                    StateHasChanged();
+                    break;
+                }
+
+                var shouldPlaySound = snapshot?.Current is not null
+                    && string.Equals(snapshot.Current.Status, "InService", StringComparison.OrdinalIgnoreCase)
+                    && snapshot.Current.TicketNo != _lastTicketNo
+                    && !_isFirstRender;
+
+                _snapshot = snapshot;
+                _isLoading = false;
+
+                if (shouldPlaySound)
+                {
+                    await PlayAudioAsync();
+                }
+
+                _lastTicketNo = snapshot?.Current?.TicketNo;
+                _isFirstRender = false;
+
+                StateHasChanged();
+            } while (_refreshPending);
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnQueueUpdated() => await RefreshAsync();
+
+    private async Task PlayAudioAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("qlineSound.playTone");
+        }
+        catch
+        {
+            // ignored on purpose
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_realtimeHandle is not null)
+            await _realtimeHandle.InvokeVoidAsync("dispose");
+    }
 }

--- a/QLine.Web/Components/Pages/Display.razor.css
+++ b/QLine.Web/Components/Pages/Display.razor.css
@@ -1,0 +1,99 @@
+.display-board {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 24px;
+    align-items: stretch;
+}
+
+.now-serving,
+.up-next {
+    background: linear-gradient(135deg, #0d6efd, #003f88);
+    color: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+}
+
+.up-next {
+    background: #f8f9fa;
+    color: #111;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 16px;
+}
+
+.section-label {
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    font-size: 18px;
+}
+
+.section-point {
+    font-size: 16px;
+    font-weight: 500;
+    opacity: 0.9;
+}
+
+.section-subtitle {
+    font-size: 14px;
+    color: #6c757d;
+}
+
+.ticket-number {
+    font-size: clamp(72px, 12vw, 160px);
+    font-weight: 900;
+    letter-spacing: 6px;
+    line-height: 1.1;
+}
+
+.now-serving-placeholder {
+    display: grid;
+    place-items: center;
+    height: 100%;
+    min-height: 240px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+}
+
+.placeholder-text {
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+}
+
+.up-next-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.up-next-item {
+    background: #fff;
+    border-radius: 10px;
+    padding: 14px 18px;
+    font-size: 28px;
+    font-weight: 700;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.empty {
+    color: #6c757d;
+    font-weight: 600;
+    font-size: 18px;
+}
+
+@media (max-width: 992px) {
+    .display-board {
+        grid-template-columns: 1fr;
+    }
+}

--- a/QLine.Web/Components/Pages/DisplaySelection.razor
+++ b/QLine.Web/Components/Pages/DisplaySelection.razor
@@ -1,0 +1,66 @@
+@page "/display"
+@attribute [Authorize(Roles = "Admin, Staff")]
+@using MediatR
+@using Microsoft.AspNetCore.Authorization
+@using QLine.Application.DTO
+@using QLine.Application.Features.Admin.Queries
+@inject IMediator Mediator
+
+<PageTitle>Display Menu</PageTitle>
+
+<h3>Display Boards</h3>
+
+@if (_loading)
+{
+    <p>Loading service points...</p>
+}
+else if (!string.IsNullOrWhiteSpace(_errorMessage))
+{
+    <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+}
+else if (_servicePoints.Count == 0)
+{
+    <p>No service points available.</p>
+}
+else
+{
+    <div class="row g-4">
+        @foreach (var sp in _servicePoints)
+        {
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title">@sp.Name</h5>
+                        <p class="card-text text-muted">@sp.Address</p>
+                        <div class="mt-auto">
+                            <a class="btn btn-primary w-100" href="/display/@sp.Id" target="_blank" rel="noopener noreferrer">Open Board</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private bool _loading = true;
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+    private List<ServicePointDto> _servicePoints = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _servicePoints = (await Mediator.Send(new GetServicePointsQuery())).ToList();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+}

--- a/QLine.Web/wwwroot/js/realtime.js
+++ b/QLine.Web/wwwroot/js/realtime.js
@@ -40,3 +40,29 @@
         };
     }
 };
+
+window.qlineSound = {
+    playTone: function () {
+        try {
+            const AudioContext = window.AudioContext || window.webkitAudioContext;
+            const ctx = new AudioContext();
+            const oscillator = ctx.createOscillator();
+            const gainNode = ctx.createGain();
+
+            oscillator.type = "sine";
+            oscillator.frequency.setValueAtTime(880, ctx.currentTime);
+
+            gainNode.gain.setValueAtTime(0.001, ctx.currentTime);
+            gainNode.gain.exponentialRampToValueAtTime(0.25, ctx.currentTime + 0.01);
+            gainNode.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.4);
+
+            oscillator.connect(gainNode);
+            gainNode.connect(ctx.destination);
+
+            oscillator.start();
+            oscillator.stop(ctx.currentTime + 0.4);
+        } catch (err) {
+            console.error("Failed to play notification sound", err);
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a protected display selection page with navigation updates for staff and admin users
- redesign the display board layout with clearer now-serving/up-next sections and add guarded notification audio
- shorten generated ticket numbers to a concise service-point-based format and add a client-side tone helper

## Testing
- dotnet test *(fails: `dotnet` CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e47f95148320aa77a2dce35bf039)