### PR TITLE
Add admin user management

### DIFF
--- a/QLine.Application/DTO/UserDto.cs
+++ b/QLine.Application/DTO/UserDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace QLine.Application.DTO
+{
+    public sealed class UserDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+    }
+}

--- a/QLine.Application/Features/Admin/Commands/UpdateUserRoleCommand.cs
+++ b/QLine.Application/Features/Admin/Commands/UpdateUserRoleCommand.cs
@@ -1,0 +1,8 @@
+using System;
+using MediatR;
+using QLine.Domain.Enums;
+
+namespace QLine.Application.Features.Admin.Commands
+{
+    public sealed record UpdateUserRoleCommand(Guid UserId, UserRole NewRole) : IRequest;
+}

--- a/QLine.Application/Features/Admin/Commands/UpdateUserRoleCommandHandler.cs
+++ b/QLine.Application/Features/Admin/Commands/UpdateUserRoleCommandHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.Abstractions;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
+
+namespace QLine.Application.Features.Admin.Commands
+{
+    public sealed class UpdateUserRoleCommandHandler : IRequestHandler<UpdateUserRoleCommand>
+    {
+        private readonly IAppUserRepository _users;
+        private readonly ICurrentUser _currentUser;
+
+        public UpdateUserRoleCommandHandler(IAppUserRepository users, ICurrentUser currentUser)
+        {
+            _users = users;
+            _currentUser = currentUser;
+        }
+
+        public async Task Handle(UpdateUserRoleCommand request, CancellationToken ct)
+        {
+            if (_currentUser.UserId.HasValue && _currentUser.UserId.Value == request.UserId)
+            {
+                throw new DomainException("You cannot change your own role.");
+            }
+
+            var user = await _users.GetByIdAsync(request.UserId, ct)
+                ?? throw new DomainException("User not found.");
+
+            user.ChangeRole(request.NewRole);
+            await _users.UpdateAsync(user, ct);
+        }
+    }
+}

--- a/QLine.Application/Features/Admin/Queries/GetAllUsersQuery.cs
+++ b/QLine.Application/Features/Admin/Queries/GetAllUsersQuery.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+using MediatR;
+using QLine.Application.DTO;
+
+namespace QLine.Application.Features.Admin.Queries
+{
+    public sealed record GetAllUsersQuery() : IRequest<IEnumerable<UserDto>>;
+}

--- a/QLine.Application/Features/Admin/Queries/GetAllUsersQueryHandler.cs
+++ b/QLine.Application/Features/Admin/Queries/GetAllUsersQueryHandler.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
+using QLine.Domain.Abstractions;
+
+namespace QLine.Application.Features.Admin.Queries
+{
+    public sealed class GetAllUsersQueryHandler : IRequestHandler<GetAllUsersQuery, IEnumerable<UserDto>>
+    {
+        private readonly IAppUserRepository _users;
+
+        public GetAllUsersQueryHandler(IAppUserRepository users) => _users = users;
+
+        public async Task<IEnumerable<UserDto>> Handle(GetAllUsersQuery request, CancellationToken ct)
+        {
+            var list = await _users.GetAllAsync(ct);
+            return list
+                .Select(u => new UserDto
+                {
+                    Id = u.Id,
+                    Name = u.FullName,
+                    Email = u.Email,
+                    Role = u.Role.ToString()
+                })
+                .ToList();
+        }
+    }
+}

--- a/QLine.Domain/Abstractions/IAppUserRepository.cs
+++ b/QLine.Domain/Abstractions/IAppUserRepository.cs
@@ -11,6 +11,7 @@ namespace QLine.Domain.Abstractions
     {
         Task<AppUser?> GetByIdAsync(Guid id, CancellationToken ct);
         Task<AppUser?> GetByEmailAsync(string email, CancellationToken ct);
+        Task<IReadOnlyList<AppUser>> GetAllAsync(CancellationToken ct);
         Task AddAsync (AppUser user, CancellationToken ct);
         Task UpdateAsync(AppUser user, CancellationToken ct);
         Task DeleteWithRelatedDataAsync(AppUser user, CancellationToken ct);

--- a/QLine.Infrastructure/Persistence/Repositories/AppUserRepository.cs
+++ b/QLine.Infrastructure/Persistence/Repositories/AppUserRepository.cs
@@ -22,6 +22,11 @@ namespace QLine.Infrastructure.Persistence.Repositories
             _db.AppUsers
                 .FirstOrDefaultAsync(u => u.Email == email, ct);
 
+        public Task<IReadOnlyList<AppUser>> GetAllAsync(CancellationToken ct) =>
+            _db.AppUsers
+                .AsNoTracking()
+                .ToListAsync(ct);
+
         public async Task AddAsync(AppUser user, CancellationToken ct)
         {
             await _db.AppUsers.AddAsync(user, ct);

--- a/QLine.Web/Components/Layout/NavMenu.razor
+++ b/QLine.Web/Components/Layout/NavMenu.razor
@@ -43,10 +43,20 @@
                         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Service Points Manager
                     </NavLink>
                 </div>
-        
+
                 <div class="nav-item px-3">
-				    <NavLink class="nav-link" href="/staff/queue">
+                                    <NavLink class="nav-link" href="/staff/queue">
                         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Queue
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+
+        <AuthorizeView Roles="Admin">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="/admin/users">
+                        <span class="bi bi-people" aria-hidden="true"></span> Users
                     </NavLink>
                 </div>
             </Authorized>

--- a/QLine.Web/Components/Pages/Admin/Users.razor
+++ b/QLine.Web/Components/Pages/Admin/Users.razor
@@ -1,5 +1,91 @@
-﻿<h3>Users</h3>
+@page "/admin/users"
+@attribute [Authorize(Roles = "Admin")]
+@using MediatR
+@using QLine.Application.Abstractions
+@using QLine.Application.DTO
+@using QLine.Application.Features.Admin.Commands
+@using QLine.Application.Features.Admin.Queries
+@using QLine.Domain.Enums
+@inject IMediator Mediator
+@inject ICurrentUser CurrentUser
+
+<h3>Users</h3>
+
+@if (_loading)
+{
+    <p>Loading users...</p>
+}
+else if (_users.Count == 0)
+{
+    <p>No users found.</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var user in _users)
+            {
+                <tr>
+                    <td>@user.Name</td>
+                    <td>@user.Email</td>
+                    <td>@user.Role</td>
+                    <td>
+                        @if (user.Role == nameof(UserRole.Client))
+                        {
+                            <button class="btn btn-success btn-sm"
+                                    disabled="@IsCurrentUser(user.Id)"
+                                    @onclick="() => UpdateRole(user.Id, UserRole.Staff)">
+                                Promote to Staff
+                            </button>
+                        }
+                        else if (user.Role == nameof(UserRole.Staff))
+                        {
+                            <button class="btn btn-warning btn-sm"
+                                    disabled="@IsCurrentUser(user.Id)"
+                                    @onclick="() => UpdateRole(user.Id, UserRole.Client)">
+                                Demote to Client
+                            </button>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
 
 @code {
+    private readonly List<UserDto> _users = new();
+    private bool _loading = true;
+    private Guid? _currentUserId;
 
+    protected override async Task OnInitializedAsync()
+    {
+        _currentUserId = CurrentUser.UserId;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _users.Clear();
+        _users.AddRange(await Mediator.Send(new GetAllUsersQuery()));
+        _loading = false;
+    }
+
+    private async Task UpdateRole(Guid userId, UserRole newRole)
+    {
+        await Mediator.Send(new UpdateUserRoleCommand(userId, newRole));
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private bool IsCurrentUser(Guid userId) => _currentUserId.HasValue && _currentUserId.Value == userId;
 }


### PR DESCRIPTION
## Summary
- add repository support for fetching all users and updating roles through CQRS handlers
- provide DTOs and admin commands/queries for listing users and changing roles safely
- implement admin users page with role promotion/demotion actions and navigation entry

## Testing
- dotnet test *(fails: dotnet CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f3b37ac88320bada4df272da8efa)