### PR TITLE
Implement staff assignment management and smart queue selection

### DIFF
--- a/QLine.Application/DTO/StaffDto.cs
+++ b/QLine.Application/DTO/StaffDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace QLine.Application.DTO
+{
+    public sealed class StaffDto
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Email { get; init; } = string.Empty;
+    }
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Commands/AssignStaffCommand.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Commands/AssignStaffCommand.cs
@@ -1,0 +1,7 @@
+using System;
+using MediatR;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Commands
+{
+    public sealed record AssignStaffCommand(Guid ServicePointId, Guid UserId) : IRequest;
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Commands/AssignStaffCommandHandler.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Commands/AssignStaffCommandHandler.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Entities;
+using QLine.Domain.Enums;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Commands
+{
+    public sealed class AssignStaffCommandHandler : IRequestHandler<AssignStaffCommand>
+    {
+        private readonly IServicePointRepository _servicePoints;
+        private readonly IAppUserRepository _users;
+
+        public AssignStaffCommandHandler(IServicePointRepository servicePoints, IAppUserRepository users)
+        {
+            _servicePoints = servicePoints;
+            _users = users;
+        }
+
+        public async Task Handle(AssignStaffCommand request, CancellationToken ct)
+        {
+            _ = await _servicePoints.GetByIdAsync(request.ServicePointId, ct)
+                ?? throw new DomainException("Service point not found.");
+
+            var user = await _users.GetByIdAsync(request.UserId, ct)
+                ?? throw new DomainException("User not found.");
+
+            if (user.Role != UserRole.Staff)
+                throw new DomainException("Only staff users can be assigned to a service point.");
+
+            var assignedStaff = await _servicePoints.GetAssignedStaffAsync(request.ServicePointId, ct);
+            if (assignedStaff.Any(s => s.Id == request.UserId))
+                return;
+
+            var assignment = StaffAssignment.Create(request.ServicePointId, request.UserId);
+            await _servicePoints.AddStaffAssignmentAsync(assignment, ct);
+        }
+    }
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Commands/UnassignStaffCommand.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Commands/UnassignStaffCommand.cs
@@ -1,0 +1,7 @@
+using System;
+using MediatR;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Commands
+{
+    public sealed record UnassignStaffCommand(Guid ServicePointId, Guid UserId) : IRequest;
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Commands/UnassignStaffCommandHandler.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Commands/UnassignStaffCommandHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Domain.Abstractions;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Commands
+{
+    public sealed class UnassignStaffCommandHandler : IRequestHandler<UnassignStaffCommand>
+    {
+        private readonly IServicePointRepository _servicePoints;
+
+        public UnassignStaffCommandHandler(IServicePointRepository servicePoints)
+        {
+            _servicePoints = servicePoints;
+        }
+
+        public async Task Handle(UnassignStaffCommand request, CancellationToken ct)
+        {
+            await _servicePoints.RemoveStaffAssignmentAsync(request.ServicePointId, request.UserId, ct);
+        }
+    }
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Queries/GetAssignedStaffQuery.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Queries/GetAssignedStaffQuery.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using MediatR;
+using QLine.Application.DTO;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Queries
+{
+    public sealed record GetAssignedStaffQuery(Guid ServicePointId) : IRequest<IReadOnlyList<StaffDto>>;
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Queries/GetAssignedStaffQueryHandler.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Queries/GetAssignedStaffQueryHandler.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Enums;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Queries
+{
+    public sealed class GetAssignedStaffQueryHandler : IRequestHandler<GetAssignedStaffQuery, IReadOnlyList<StaffDto>>
+    {
+        private readonly IServicePointRepository _servicePoints;
+
+        public GetAssignedStaffQueryHandler(IServicePointRepository servicePoints)
+        {
+            _servicePoints = servicePoints;
+        }
+
+        public async Task<IReadOnlyList<StaffDto>> Handle(GetAssignedStaffQuery request, CancellationToken ct)
+        {
+            var assigned = await _servicePoints.GetAssignedStaffAsync(request.ServicePointId, ct);
+            return assigned
+                .Where(u => u.Role == UserRole.Staff)
+                .Select(u => new StaffDto
+                {
+                    Id = u.Id,
+                    Name = u.FullName,
+                    Email = u.Email
+                })
+                .ToList();
+        }
+    }
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Queries/GetUnassignedStaffQuery.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Queries/GetUnassignedStaffQuery.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using MediatR;
+using QLine.Application.DTO;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Queries
+{
+    public sealed record GetUnassignedStaffQuery(Guid ServicePointId) : IRequest<IReadOnlyList<StaffDto>>;
+}

--- a/QLine.Application/Features/Admin/ServicePoints/Queries/GetUnassignedStaffQueryHandler.cs
+++ b/QLine.Application/Features/Admin/ServicePoints/Queries/GetUnassignedStaffQueryHandler.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.DTO;
+using QLine.Domain.Abstractions;
+using QLine.Domain.Enums;
+
+namespace QLine.Application.Features.Admin.ServicePoints.Queries
+{
+    public sealed class GetUnassignedStaffQueryHandler : IRequestHandler<GetUnassignedStaffQuery, IReadOnlyList<StaffDto>>
+    {
+        private readonly IServicePointRepository _servicePoints;
+        private readonly IAppUserRepository _users;
+
+        public GetUnassignedStaffQueryHandler(IServicePointRepository servicePoints, IAppUserRepository users)
+        {
+            _servicePoints = servicePoints;
+            _users = users;
+        }
+
+        public async Task<IReadOnlyList<StaffDto>> Handle(GetUnassignedStaffQuery request, CancellationToken ct)
+        {
+            var assigned = await _servicePoints.GetAssignedStaffAsync(request.ServicePointId, ct);
+            var all = await _users.GetAllAsync(ct);
+
+            var assignedIds = assigned.Select(a => a.Id).ToHashSet();
+
+            return all
+                .Where(u => u.Role == UserRole.Staff && !assignedIds.Contains(u.Id))
+                .Select(u => new StaffDto
+                {
+                    Id = u.Id,
+                    Name = u.FullName,
+                    Email = u.Email
+                })
+                .OrderBy(u => u.Name)
+                .ToList();
+        }
+    }
+}

--- a/QLine.Application/Features/Queue/Queries/GetMyServicePointsQuery.cs
+++ b/QLine.Application/Features/Queue/Queries/GetMyServicePointsQuery.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+using MediatR;
+using QLine.Application.DTO;
+
+namespace QLine.Application.Features.Queue.Queries
+{
+    public sealed record GetMyServicePointsQuery() : IRequest<IReadOnlyList<ServicePointDto>>;
+}

--- a/QLine.Application/Features/Queue/Queries/GetMyServicePointsQueryHandler.cs
+++ b/QLine.Application/Features/Queue/Queries/GetMyServicePointsQueryHandler.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QLine.Application.Abstractions;
+using QLine.Application.DTO;
+using QLine.Domain;
+using QLine.Domain.Abstractions;
+
+namespace QLine.Application.Features.Queue.Queries
+{
+    public sealed class GetMyServicePointsQueryHandler : IRequestHandler<GetMyServicePointsQuery, IReadOnlyList<ServicePointDto>>
+    {
+        private readonly IServicePointRepository _servicePoints;
+        private readonly ICurrentUser _currentUser;
+
+        public GetMyServicePointsQueryHandler(IServicePointRepository servicePoints, ICurrentUser currentUser)
+        {
+            _servicePoints = servicePoints;
+            _currentUser = currentUser;
+        }
+
+        public async Task<IReadOnlyList<ServicePointDto>> Handle(GetMyServicePointsQuery request, CancellationToken ct)
+        {
+            if (_currentUser.UserId is null)
+                throw new DomainException("User is not authenticated.");
+
+            var list = await _servicePoints.GetAssignedServicePointsAsync(_currentUser.UserId.Value, ct);
+
+            return list
+                .Select(sp => new ServicePointDto
+                {
+                    Id = sp.Id,
+                    Name = sp.Name,
+                    Address = sp.Address,
+                    OpenHoursJson = sp.OpenHoursJson
+                })
+                .ToList();
+        }
+    }
+}

--- a/QLine.Domain/Abstractions/IServicePointRepository.cs
+++ b/QLine.Domain/Abstractions/IServicePointRepository.cs
@@ -14,5 +14,9 @@ namespace QLine.Domain.Abstractions
         Task AddAsync(ServicePoint sp, CancellationToken ct);
         Task UpdateAsync(ServicePoint sp, CancellationToken ct);
         Task DeleteAsync(Guid id, CancellationToken ct);
+        Task AddStaffAssignmentAsync(StaffAssignment assignment, CancellationToken ct);
+        Task RemoveStaffAssignmentAsync(Guid servicePointId, Guid userId, CancellationToken ct);
+        Task<IReadOnlyList<AppUser>> GetAssignedStaffAsync(Guid servicePointId, CancellationToken ct);
+        Task<IReadOnlyList<ServicePoint>> GetAssignedServicePointsAsync(Guid userId, CancellationToken ct);
     }
 }

--- a/QLine.Domain/Entities/StaffAssignment.cs
+++ b/QLine.Domain/Entities/StaffAssignment.cs
@@ -1,12 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+using QLine.Domain;
 
 namespace QLine.Domain.Entities
 {
     public class StaffAssignment
     {
+        public Guid ServicePointId { get; private set; }
+        public Guid UserId { get; private set; }
+
+        private StaffAssignment() { }
+
+        private StaffAssignment(Guid servicePointId, Guid userId)
+        {
+            if (servicePointId == Guid.Empty)
+                throw new DomainException("ServicePointId cannot be empty.");
+            if (userId == Guid.Empty)
+                throw new DomainException("UserId cannot be empty.");
+
+            ServicePointId = servicePointId;
+            UserId = userId;
+        }
+
+        public static StaffAssignment Create(Guid servicePointId, Guid userId) =>
+            new(servicePointId, userId);
     }
 }

--- a/QLine.Infrastructure/Migrations/20251221191200_AddStaffAssignments.cs
+++ b/QLine.Infrastructure/Migrations/20251221191200_AddStaffAssignments.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLine.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStaffAssignments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StaffAssignments",
+                columns: table => new
+                {
+                    ServicePointId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StaffAssignments", x => new { x.ServicePointId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_StaffAssignments_AppUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AppUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_StaffAssignments_ServicePoints_ServicePointId",
+                        column: x => x.ServicePointId,
+                        principalTable: "ServicePoints",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StaffAssignments_UserId",
+                table: "StaffAssignments",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StaffAssignments");
+        }
+    }
+}

--- a/QLine.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/QLine.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -187,6 +187,21 @@ namespace QLine.Infrastructure.Migrations
                     b.ToTable("ServicePoints");
                 });
 
+            modelBuilder.Entity("QLine.Domain.Entities.StaffAssignment", b =>
+                {
+                    b.Property<Guid>("ServicePointId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("ServicePointId", "UserId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("StaffAssignments");
+                });
+
             modelBuilder.Entity("QLine.Domain.Entities.Reservation", b =>
                 {
                     b.HasOne("QLine.Domain.Entities.Service", "Service")
@@ -196,6 +211,21 @@ namespace QLine.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("Service");
+                });
+
+            modelBuilder.Entity("QLine.Domain.Entities.StaffAssignment", b =>
+                {
+                    b.HasOne("QLine.Domain.Entities.AppUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("QLine.Domain.Entities.ServicePoint", null)
+                        .WithMany()
+                        .HasForeignKey("ServicePointId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 #pragma warning restore 612, 618
         }

--- a/QLine.Infrastructure/Persistence/AppDbContext.cs
+++ b/QLine.Infrastructure/Persistence/AppDbContext.cs
@@ -17,6 +17,7 @@ namespace QLine.Infrastructure.Persistence
         public DbSet<Reservation> Reservations => Set<Reservation>();
         public DbSet<QueueEntry> QueueEntries => Set<QueueEntry>();
         public DbSet<AppUser> AppUsers => Set<AppUser>();
+        public DbSet<StaffAssignment> StaffAssignments => Set<StaffAssignment>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/QLine.Infrastructure/Persistence/Configurations/StaffAssignmentConfiguration.cs
+++ b/QLine.Infrastructure/Persistence/Configurations/StaffAssignmentConfiguration.cs
@@ -1,12 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QLine.Domain.Entities;
 
 namespace QLine.Infrastructure.Persistence.Configurations
 {
-    public class StaffAssignmentConfiguration
+    public class StaffAssignmentConfiguration : IEntityTypeConfiguration<StaffAssignment>
     {
+        public void Configure(EntityTypeBuilder<StaffAssignment> b)
+        {
+            b.HasKey(x => new { x.ServicePointId, x.UserId });
+
+            b.HasIndex(x => x.UserId);
+
+            b.HasOne<ServicePoint>()
+                .WithMany()
+                .HasForeignKey(x => x.ServicePointId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            b.HasOne<AppUser>()
+                .WithMany()
+                .HasForeignKey(x => x.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
     }
 }

--- a/QLine.Web/Components/Pages/Admin/ServicePoints.razor
+++ b/QLine.Web/Components/Pages/Admin/ServicePoints.razor
@@ -38,22 +38,27 @@
 </div>
 
 <table>
-	<thead><tr><th>Name</th><th>Address</th><th></th></tr></thead>
-	<tbody>
-		@foreach (var sp in _list)
-		{
-			<tr>
-				<td>@sp.Name</td>
-				<td>@sp.Address</td>
-				<td>
-					<button @onclick="() => Edit(sp)">Edit</button>
-					<button @onclick="() => DeleteAsync(sp.Id)" style="margin-left:6px;">Delete</button>
-					<a href="@($"/admin/services/{sp.Id}")" style="margin-left:12px;">Services</a>
-				</td>
-			</tr>
-		}
-	</tbody>
+        <thead><tr><th>Name</th><th>Address</th><th></th></tr></thead>
+        <tbody>
+                @foreach (var sp in _list)
+                {
+                        <tr>
+                                <td>@sp.Name</td>
+                                <td>@sp.Address</td>
+                                <td>
+                                        <button @onclick="() => Edit(sp)">Edit</button>
+                                        <button @onclick="() => DeleteAsync(sp.Id)" style="margin-left:6px;">Delete</button>
+                                        <a href="@($"/admin/services/{sp.Id}")" style="margin-left:12px;">Services</a>
+                                        <button @onclick="() => OpenStaffModal(sp)" style="margin-left:12px;">
+                                                <i class="bi bi-people"></i> Staff
+                                        </button>
+                                </td>
+                        </tr>
+                }
+        </tbody>
 </table>
+
+<StaffAssignmentModal Visible="@_showStaffModal" ServicePointId="@_staffModalServicePointId" ServicePointName="@_staffModalServicePointName" OnClose="CloseStaffModal" />
 
 @code {
     private List<ServicePointDto> _list = new();
@@ -64,8 +69,12 @@
 	private string? _formOpenHoursJson = DefaultOpenHoursJson();
 	private bool _openHoursValid = true;
 
-	private string? _errorMessage;
-	private List<string>? _errorDetails;
+        private string? _errorMessage;
+        private List<string>? _errorDetails;
+
+        private bool _showStaffModal;
+        private Guid _staffModalServicePointId;
+        private string? _staffModalServicePointName;
 
 	private static string DefaultOpenHoursJson() =>
 		"""{ "monday":{"open":true, "start":"07:30","end":"16:00"}, "tuesday":{"open":true, "start":"07:30","end":"16:00"}, "wednesday":{"open":true, "start":"07:30","end":"16:00"}, "thursday":{"open":true, "start":"07:30","end":"16:00"}, "friday":{"open":true, "start":"07:30","end":"16:00"}, "saturday":{"open":false, "start":"07:30","end":"16:00"}, "sunday":{"open":false, "start":"07:30","end":"16:00"} }""";
@@ -135,18 +144,30 @@
 		}
 	}
 
-	private async Task DeleteAsync(Guid id)
-	{
-		try
-		{
-			await Mediator.Send(new DeleteServicePointCommand(id));
-			await LoadAsync();
-			StateHasChanged();
-		}
-		catch (Exception ex)
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
+        private async Task DeleteAsync(Guid id)
+        {
+                try
+                {
+                        await Mediator.Send(new DeleteServicePointCommand(id));
+                        await LoadAsync();
+                        StateHasChanged();
+                }
+                catch (Exception ex)
+                {
+                        (_errorMessage, _errorDetails) = ex.ToUserMessage();
+                }
 
-	}
+        }
+
+        private void OpenStaffModal(ServicePointDto sp)
+        {
+                _staffModalServicePointId = sp.Id;
+                _staffModalServicePointName = sp.Name;
+                _showStaffModal = true;
+        }
+
+        private void CloseStaffModal()
+        {
+                _showStaffModal = false;
+        }
 }

--- a/QLine.Web/Components/Pages/Admin/StaffAssignmentModal.razor
+++ b/QLine.Web/Components/Pages/Admin/StaffAssignmentModal.razor
@@ -1,0 +1,150 @@
+@using MediatR
+@using QLine.Application.DTO
+@using QLine.Application.Features.Admin.ServicePoints.Commands
+@using QLine.Application.Features.Admin.ServicePoints.Queries
+
+@if (!Visible)
+{
+    <div style="display:none"></div>
+}
+else
+{
+    <div class="modal-backdrop" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.4);z-index:1000;" @onclick="CloseAsync"></div>
+    <div class="modal-dialog" style="position:fixed;top:10%;left:50%;transform:translateX(-50%);background:#fff;padding:16px;border-radius:8px;z-index:1001;min-width:320px;max-width:520px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+            <h4 style="margin:0;">Staff for @ServicePointName</h4>
+            <button @onclick="CloseAsync">&times;</button>
+        </div>
+
+        <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+
+        <div style="margin-bottom:16px;">
+            <h5>Add Staff</h5>
+            <div style="display:flex;gap:8px;align-items:center;">
+                <select @bind="_selectedUserIdString" style="flex:1;">
+                    <option value="">-- Select Staff --</option>
+                    @foreach (var staff in _unassigned)
+                    {
+                        <option value="@staff.Id">@staff.Name (@staff.Email)</option>
+                    }
+                </select>
+                <button @onclick="AssignAsync" disabled="string.IsNullOrWhiteSpace(_selectedUserIdString)">Assign</button>
+            </div>
+        </div>
+
+        <div>
+            <h5>Assigned Staff</h5>
+            @if (_assigned.Count == 0)
+            {
+                <p>(none)</p>
+            }
+            else
+            {
+                <table style="width:100%;">
+                    <thead>
+                        <tr><th style="text-align:left;">Name</th><th style="text-align:left;">Email</th><th style="width:80px;"></th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var staff in _assigned)
+                        {
+                            <tr>
+                                <td>@staff.Name</td>
+                                <td>@staff.Email</td>
+                                <td><button @onclick="() => UnassignAsync(staff.Id)" title="Remove"><i class="bi bi-trash"></i></button></td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public bool Visible { get; set; }
+
+    [Parameter]
+    public Guid ServicePointId { get; set; }
+
+    [Parameter]
+    public string? ServicePointName { get; set; }
+
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
+    [Inject]
+    public IMediator Mediator { get; set; } = default!;
+
+    private List<StaffDto> _assigned = new();
+    private List<StaffDto> _unassigned = new();
+    private Guid? _currentServicePointId;
+    private string? _selectedUserIdString;
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!Visible) return;
+        if (_currentServicePointId != ServicePointId)
+        {
+            _currentServicePointId = ServicePointId;
+            _selectedUserIdString = null;
+        }
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        if (!Visible) return;
+
+        try
+        {
+            _errorMessage = null; _errorDetails = null;
+            _assigned = (await Mediator.Send(new GetAssignedStaffQuery(ServicePointId))).ToList();
+            _unassigned = (await Mediator.Send(new GetUnassignedStaffQuery(ServicePointId))).ToList();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+    }
+
+    private async Task AssignAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_selectedUserIdString)) return;
+        if (!Guid.TryParse(_selectedUserIdString, out var userId)) return;
+
+        try
+        {
+            await Mediator.Send(new AssignStaffCommand(ServicePointId, userId));
+            _selectedUserIdString = null;
+            await LoadAsync();
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+    }
+
+    private async Task UnassignAsync(Guid userId)
+    {
+        try
+        {
+            await Mediator.Send(new UnassignStaffCommand(ServicePointId, userId));
+            await LoadAsync();
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+    }
+
+    private async Task CloseAsync()
+    {
+        if (OnClose.HasDelegate)
+            await OnClose.InvokeAsync();
+    }
+}

--- a/QLine.Web/Components/Pages/Staff/Queue.razor
+++ b/QLine.Web/Components/Pages/Staff/Queue.razor
@@ -4,7 +4,6 @@
 @using Microsoft.JSInterop
 @using MediatR
 @using QLine.Application.DTO
-@using QLine.Application.Features.Admin.Queries
 @using QLine.Application.Features.Queue.Queries
 @using QLine.Application.Features.Queue.Commands
 @inject IMediator Mediator
@@ -12,109 +11,181 @@
 
 <h3>Staff Queue</h3>
 
-<div style="margin:6px 0 12px 0;">
-	<label style="margin-right: 8px;">Service Point:</label>
-	<select @bind="SelectedServicePointIdString" @bind:after="OnServicePointChanged">
-		@foreach (var sp in _points)
-		{
-			<option value="@sp.Id.ToString()">@sp.Name</option>
-		}
-	</select>
-	<button @onclick="CallNextAsync" style="margin-left: 8px;">Call Next</button>
-</div>
-
-@if (string.IsNullOrWhiteSpace(SelectedServicePointIdString) || !Guid.TryParse(SelectedServicePointIdString, out var _))
+@if (!string.IsNullOrWhiteSpace(_accessMessage))
 {
-	<p class="text-danger">Select a Service Point.</p>
-}
-else if (_snapshot is null)
-{
-	<p>Loading...</p>
+        <p class="text-danger">@_accessMessage</p>
 }
 else
 {
-	<h4>In Service</h4>
-	@if (_snapshot.Current is null)
-	{
-		<p>(none)</p>
-	}
-	else
-	{
-		<div class="card">
-			<div><strong>@_snapshot.Current.TicketNo</strong></div>
-			<div><strong>Status: </strong>@_snapshot.Current.Status</div>
-			<div><strong>Priority: </strong>@_snapshot.Current.Priority</div>
-			<div>
-				<button @onclick="() => MarkDoneAsync(_snapshot.Current!.Id)">Done</button>
-				<button @onclick="() => MarkNoShowAsync(_snapshot.Current!.Id)" style="margin-left: 6px;">No-show</button>
-			</div>
-		</div>
-	}
+        @if (_points.Count > 1 && !HasSelectedServicePoint)
+        {
+                <div class="card">
+                        <h5>Where are you working today?</h5>
+                        <div style="display:flex;align-items:center;gap:8px;">
+                                <select @bind="_selectionCandidateId" style="flex:1;">
+                                        @foreach (var sp in _points)
+                                        {
+                                                <option value="@sp.Id.ToString()">@sp.Name</option>
+                                        }
+                                </select>
+                                <button @onclick="ConfirmServicePointAsync">Load Queue</button>
+                        </div>
+                        @if (!string.IsNullOrWhiteSpace(_selectionError))
+                        {
+                                <p class="text-danger">@_selectionError</p>
+                        }
+                </div>
+        }
 
-	<h4 style="margin:16px;">Waiting</h4>
-	@if (_snapshot.Waiting.Count == 0)
-	{
-		<p>(empty)</p>
-	}
-	else
-	{
-		<ul>
-			@foreach (var w in _snapshot.Waiting)
-			{
-				<li>
-					<strong>@w.TicketNo</strong> - created @w.CreatedAt.ToString("u") (prio @w.Priority)
-					<button @onclick="() => SkipAsync(w.Id)">Skip</button>
-				</li>
-			}
-		</ul>
-	}
+        @if (HasSelectedServicePoint)
+        {
+                <div style="margin:6px 0 12px 0;">
+                        <label style="margin-right: 8px;">Service Point:</label>
+                        <select @bind="SelectedServicePointIdString" @bind:after="OnServicePointChanged">
+                                @foreach (var sp in _points)
+                                {
+                                        <option value="@sp.Id.ToString()">@sp.Name</option>
+                                }
+                        </select>
+                        <button @onclick="CallNextAsync" style="margin-left: 8px;">Call Next</button>
+                </div>
+
+                @if (_snapshot is null)
+                {
+                        <p>Loading...</p>
+                }
+                else
+                {
+                        <h4>In Service</h4>
+                        @if (_snapshot.Current is null)
+                        {
+                                <p>(none)</p>
+                        }
+                        else
+                        {
+                                <div class="card">
+                                        <div><strong>@_snapshot.Current.TicketNo</strong></div>
+                                        <div><strong>Status: </strong>@_snapshot.Current.Status</div>
+                                        <div><strong>Priority: </strong>@_snapshot.Current.Priority</div>
+                                        <div>
+                                                <button @onclick="() => MarkDoneAsync(_snapshot.Current!.Id)">Done</button>
+                                                <button @onclick="() => MarkNoShowAsync(_snapshot.Current!.Id)" style="margin-left: 6px;">No-show</button>
+                                        </div>
+                                </div>
+                        }
+
+                        <h4 style="margin:16px;">Waiting</h4>
+                        @if (_snapshot.Waiting.Count == 0)
+                        {
+                                <p>(empty)</p>
+                        }
+                        else
+                        {
+                                <ul>
+                                        @foreach (var w in _snapshot.Waiting)
+                                        {
+                                                <li>
+                                                        <strong>@w.TicketNo</strong> - created @w.CreatedAt.ToString("u") (prio @w.Priority)
+                                                        <button @onclick="() => SkipAsync(w.Id)">Skip</button>
+                                                </li>
+                                        }
+                                </ul>
+                        }
+                }
+        }
 }
 
 @code {
-	private List<ServicePointDto> _points = new();
+        private List<ServicePointDto> _points = new();
 
-	private string? SelectedServicePointIdString;
+        private string? SelectedServicePointIdString;
+        private string? _selectionCandidateId;
+        private string? _selectionError;
+        private string? _accessMessage;
 
-	private IJSObjectReference? _realtimeHandle;
-	private Guid? _connectedSpId;
-	private bool _realtimeReady;
+        private IJSObjectReference? _realtimeHandle;
+        private Guid? _connectedSpId;
+        private bool _realtimeReady;
 
-	private QueueSnapshotDto? _snapshot;
+        private QueueSnapshotDto? _snapshot;
 
-	private readonly SemaphoreSlim _refreshGate = new(1, 1);
+        private readonly SemaphoreSlim _refreshGate = new(1, 1);
 
-	protected override async Task OnInitializedAsync()
-	{
-		_points = (await Mediator.Send(new GetServicePointsQuery())).ToList();
+        private bool HasSelectedServicePoint =>
+                Guid.TryParse(SelectedServicePointIdString, out var sp) && _points.Any(p => p.Id == sp);
 
-		if (_points.Count > 0)
-			SelectedServicePointIdString = _points[0].Id.ToString();
+        protected override async Task OnInitializedAsync()
+        {
+                _points = (await Mediator.Send(new GetMyServicePointsQuery())).ToList();
 
-		await RefreshAsync();
-	}
+                if (_points.Count == 0)
+                {
+                        _accessMessage = "You are not assigned to any service point. Please contact an administrator.";
+                        return;
+                }
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-		if (firstRender)
-		{
-			_realtimeReady = true;
-			await ConnectToRealtimeAsync();
-		}
-	}
+                if (_points.Count == 1)
+                {
+                        SelectedServicePointIdString = _points[0].Id.ToString();
+                        await RefreshAsync();
+                }
+                else
+                {
+                        _selectionCandidateId = _points[0].Id.ToString();
+                }
+        }
 
-	private async Task OnServicePointChanged()
-	{
-		await ConnectToRealtimeAsync();
-		await RefreshAsync();
-	}
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+                if (firstRender)
+                {
+                        _realtimeReady = true;
+                        if (HasSelectedServicePoint)
+                                await ConnectToRealtimeAsync();
+                }
+        }
 
-	private async Task ConnectToRealtimeAsync()
-	{
-		if (!_realtimeReady) return;
-		if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
-		if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+        private async Task OnServicePointChanged()
+        {
+                if (!HasSelectedServicePoint)
+                {
+                        _selectionError = "Invalid service point selection.";
+                        StateHasChanged();
+                        return;
+                }
 
-		if (_connectedSpId == sp) return;
+                await ConnectToRealtimeAsync();
+                await RefreshAsync();
+        }
+
+        private async Task ConfirmServicePointAsync()
+        {
+                if (string.IsNullOrWhiteSpace(_selectionCandidateId) || !Guid.TryParse(_selectionCandidateId, out var candidate))
+                {
+                        _selectionError = "Select a service point.";
+                        return;
+                }
+
+                if (!_points.Any(p => p.Id == candidate))
+                {
+                        _selectionError = "You cannot select this service point.";
+                        return;
+                }
+
+                SelectedServicePointIdString = candidate.ToString();
+                _selectionError = null;
+
+                await OnServicePointChanged();
+        }
+
+        private async Task ConnectToRealtimeAsync()
+        {
+                if (!_realtimeReady) return;
+                if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
+                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+                if (!_points.Any(p => p.Id == sp)) return;
+
+                if (_connectedSpId == sp) return;
 
 		if (_realtimeHandle is not null)
 		{
@@ -135,12 +206,13 @@ else
 		_connectedSpId = sp;
 	}
 
-	private async Task RefreshAsync()
-	{
-		if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
-		if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+        private async Task RefreshAsync()
+        {
+                if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
+                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+                if (!_points.Any(p => p.Id == sp)) return;
 
-		await _refreshGate.WaitAsync();
+                await _refreshGate.WaitAsync();
 		try
 		{
 			_snapshot = await Mediator.Send(new GetQueueQuery(sp));
@@ -161,9 +233,10 @@ else
 			await _realtimeHandle.InvokeVoidAsync("dispose");
 	}
 
-	private async Task CallNextAsync()
-	{
-		if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+        private async Task CallNextAsync()
+        {
+                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+                if (!_points.Any(p => p.Id == sp)) return;
 
 		await _refreshGate.WaitAsync();
 		try
@@ -176,11 +249,11 @@ else
 		}
 	}
 
-	private async Task MarkNoShowAsync(Guid id)
-	{
-		await _refreshGate.WaitAsync();
-		try
-		{
+        private async Task MarkNoShowAsync(Guid id)
+        {
+                await _refreshGate.WaitAsync();
+                try
+                {
 			await Mediator.Send(new MarkNoShowCommand(id));
 		}
 		finally
@@ -189,11 +262,11 @@ else
 		}
 	}
 
-	private async Task MarkDoneAsync(Guid id)
-	{
-		await _refreshGate.WaitAsync();
-		try
-		{
+        private async Task MarkDoneAsync(Guid id)
+        {
+                await _refreshGate.WaitAsync();
+                try
+                {
 			await Mediator.Send(new MarkDoneCommand(id));
 		}
 		finally
@@ -202,10 +275,10 @@ else
 		}
 	}
 
-	private async Task SkipAsync(Guid id)
-	{
-		await _refreshGate.WaitAsync();
-		try
+        private async Task SkipAsync(Guid id)
+        {
+                await _refreshGate.WaitAsync();
+                try
 		{
 			await Mediator.Send(new SkipQueueEntryCommand(id));
 		}


### PR DESCRIPTION
## Summary
- add staff assignment domain, repository operations, and database migration
- implement commands and queries for assigning/unassigning staff and retrieving service point access
- update admin service point page with staff assignment modal and smart staff queue selection experience

## Testing
- `dotnet test` *(fails: dotnet CLI not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae4983c488320b2ff995eae55ecfc)