### PR TITLE
Integrate MudBlazor theming

### DIFF
--- a/QLine.Web/Components/App.razor
+++ b/QLine.Web/Components/App.razor
@@ -6,6 +6,7 @@
     <title>QLine</title>
     <base href="/" />
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="QLine.Web.styles.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
@@ -22,6 +23,7 @@
     </div>
 
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/time.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.17/signalr.min.js" integrity="sha512-85w7H/gNoFZdG67JR2Ab1lvcG2gRNQGVJzKixMX5ii0/4TWVbmraeXorpdBlk+/Zhuc4BqkFcbTw5IB7HU4FRA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="js/realtime.js"></script>

--- a/QLine.Web/Components/Layout/MainLayout.razor
+++ b/QLine.Web/Components/Layout/MainLayout.razor
@@ -1,23 +1,60 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
+<MudThemeProvider Theme="@CurrentTheme" IsDarkMode="@isDarkMode">
+    <MudDialogProvider>
+        <MudSnackbarProvider>
+            <div class="page">
+                <div class="sidebar">
+                    <NavMenu />
+                </div>
 
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
+                <main>
+                    <div class="top-row px-4">
+                        <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+                    </div>
 
-        <article class="content px-4">
-            @Body
-        </article>
-    </main>
+                    <article class="content px-4">
+                        @Body
+                    </article>
+                </main>
 
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
-    </div>
-</div>
+                <div id="blazor-error-ui">
+                    An unhandled error has occurred.
+                    <a href="" class="reload">Reload</a>
+                    <a class="dismiss">🗙</a>
+                </div>
+            </div>
+        </MudSnackbarProvider>
+    </MudDialogProvider>
+</MudThemeProvider>
+
+@code {
+    private readonly MudTheme lightTheme = new()
+    {
+        Palette = new Palette
+        {
+            Primary = "#0d6efd"
+        }
+    };
+
+    private readonly MudTheme darkTheme = new()
+    {
+        Palette = new PaletteDark
+        {
+            Primary = "#0d6efd",
+            Background = "#121212",
+            Surface = "#1e1e1e",
+            DrawerBackground = "#1f1f1f",
+            AppbarBackground = "#1f1f1f",
+            AppbarText = "#ffffff",
+            DrawerText = "#ffffff",
+            TextPrimary = "#ffffff"
+        }
+    };
+
+    private bool isDarkMode;
+
+    private MudTheme CurrentTheme => isDarkMode ? darkTheme : lightTheme;
+
+    public void ToggleTheme() => isDarkMode = !isDarkMode;
+}

--- a/QLine.Web/Program.cs
+++ b/QLine.Web/Program.cs
@@ -50,6 +50,8 @@ services.AddServerSideBlazor().AddCircuitOptions(options =>
     options.DetailedErrors = true;
 });
 
+services.AddMudServices();
+
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())


### PR DESCRIPTION
## Summary
- register MudBlazor services and assets for the Blazor app
- wrap the main layout with MudBlazor providers and theming support
- add light/dark theme definitions with a primary brand color

## Testing
- `dotnet build QLine.sln` *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1c52743c8320926c2f530efdee64)