### PR TITLE
Update staff queue interface with MudBlazor layout

### DIFF
--- a/QLine.Web/Components/Pages/Staff/Queue.razor
+++ b/QLine.Web/Components/Pages/Staff/Queue.razor
@@ -1,5 +1,6 @@
-﻿@page "/staff/queue"
+@page "/staff/queue"
 @attribute [Authorize(Policy = "StaffOnly")]
+@using System.Timers
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
 @using MediatR
@@ -9,282 +10,437 @@
 @inject IMediator Mediator
 @inject IJSRuntime JS
 
-<h3>Staff Queue</h3>
+<MudStack Spacing="3">
+    <MudText Typo="Typo.h4" Class="font-weight-bold">Staff Queue</MudText>
 
-@if (!string.IsNullOrWhiteSpace(_accessMessage))
-{
-        <p class="text-danger">@_accessMessage</p>
-}
-else
-{
+    @if (!string.IsNullOrWhiteSpace(_accessMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Filled">@_accessMessage</MudAlert>
+    }
+    else
+    {
         @if (_points.Count > 1 && !HasSelectedServicePoint)
         {
-                <div class="card">
-                        <h5>Where are you working today?</h5>
-                        <div style="display:flex;align-items:center;gap:8px;">
-                                <select @bind="_selectionCandidateId" style="flex:1;">
-                                        @foreach (var sp in _points)
-                                        {
-                                                <option value="@sp.Id.ToString()">@sp.Name</option>
-                                        }
-                                </select>
-                                <button @onclick="ConfirmServicePointAsync">Load Queue</button>
-                        </div>
-                        @if (!string.IsNullOrWhiteSpace(_selectionError))
-                        {
-                                <p class="text-danger">@_selectionError</p>
-                        }
-                </div>
+            <MudCard Elevation="1">
+                <MudCardHeader Title="Where are you working today?" />
+                <MudCardContent>
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudSelect @bind-Value="_selectionCandidateId" FullWidth="true" Label="Service Point">
+                            @foreach (var sp in _points)
+                            {
+                                <MudSelectItem Value="@sp.Id.ToString()">@sp.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmServicePointAsync">Load Queue</MudButton>
+                    </MudStack>
+                    @if (!string.IsNullOrWhiteSpace(_selectionError))
+                    {
+                        <MudText Color="Color.Error" Typo="Typo.caption">@_selectionError</MudText>
+                    }
+                </MudCardContent>
+            </MudCard>
         }
 
         @if (HasSelectedServicePoint)
         {
-                <div style="margin:6px 0 12px 0;">
-                        <label style="margin-right: 8px;">Service Point:</label>
-                        <select @bind="SelectedServicePointIdString" @bind:after="OnServicePointChanged">
-                                @foreach (var sp in _points)
-                                {
-                                        <option value="@sp.Id.ToString()">@sp.Name</option>
-                                }
-                        </select>
-                        <button @onclick="CallNextAsync" style="margin-left: 8px;">Call Next</button>
-                </div>
+            <MudPaper Class="pa-3" Elevation="1">
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                    <MudText Typo="Typo.subtitle1">Service Point:</MudText>
+                    <MudSelect @bind-Value="SelectedServicePointIdString" @bind-Value:after="OnServicePointChanged" Label="Select" Immediate="true" Dense="true">
+                        @foreach (var sp in _points)
+                        {
+                            <MudSelectItem Value="@sp.Id.ToString()">@sp.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudSpacer />
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CallNextAsync" Disabled="_isProcessing">
+                        <MudIcon Icon="@Icons.Material.Filled.NextPlan" Class="mr-1" />
+                        Call Next
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
 
-                @if (_snapshot is null)
-                {
-                        <p>Loading...</p>
-                }
-                else
-                {
-                        <h4>In Service</h4>
-                        @if (_snapshot.Current is null)
-                        {
-                                <p>(none)</p>
-                        }
-                        else
-                        {
-                                <div class="card">
-                                        <div><strong>@_snapshot.Current.TicketNo</strong></div>
-                                        <div><strong>Status: </strong>@_snapshot.Current.Status</div>
-                                        <div><strong>Priority: </strong>@_snapshot.Current.Priority</div>
-                                        <div>
-                                                <button @onclick="() => MarkDoneAsync(_snapshot.Current!.Id)">Done</button>
-                                                <button @onclick="() => MarkNoShowAsync(_snapshot.Current!.Id)" style="margin-left: 6px;">No-show</button>
-                                        </div>
-                                </div>
-                        }
+            <MudGrid Class="mt-2" Spacing="3">
+                <MudItem xs="12" md="8">
+                    <MudCard Elevation="3" Class="high-emphasis-card">
+                        <MudCardHeader Title="Current Ticket" />
+                        <MudCardContent>
+                            @if (_snapshot is null)
+                            {
+                                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Class="my-4" />
+                            }
+                            else if (_snapshot.Current is null)
+                            {
+                                <MudText Typo="Typo.subtitle1" Color="Color.Secondary">No ticket in service.</MudText>
+                            }
+                            else
+                            {
+                                <MudStack Spacing="2">
+                                    <MudPaper Elevation="0" Class="pa-3 high-emphasis-card">
+                                        <MudText Typo="Typo.subtitle2" Color="Color.Primary">Now Serving</MudText>
+                                        <MudText Typo="Typo.h1" Class="font-weight-bold">@_snapshot.Current.TicketNo</MudText>
+                                        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                            <MudChip Color="Color.Primary" Variant="Variant.Filled">@_snapshot.Current.Status</MudChip>
+                                            <MudChip Color="Color.Info" Variant="Variant.Outlined">Priority @_snapshot.Current.Priority</MudChip>
+                                            <MudText Color="@GetDurationColor(_snapshot.Current.CreatedAt)" Typo="Typo.subtitle1" Class="font-weight-bold">
+                                                @FormatDuration(_snapshot.Current.CreatedAt)
+                                            </MudText>
+                                        </MudStack>
+                                    </MudPaper>
 
-                        <h4 style="margin:16px;">Waiting</h4>
-                        @if (_snapshot.Waiting.Count == 0)
-                        {
-                                <p>(empty)</p>
-                        }
-                        else
-                        {
-                                <ul>
-                                        @foreach (var w in _snapshot.Waiting)
-                                        {
-                                                <li>
-                                                        <strong>@w.TicketNo</strong> - created @w.CreatedAt.ToString("u") (prio @w.Priority)
-                                                        <button @onclick="() => SkipAsync(w.Id)">Skip</button>
-                                                </li>
-                                        }
-                                </ul>
-                        }
-                }
+                                    <MudStack Row="true" Spacing="2">
+                                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" OnClick="CallNextAsync" Disabled="_isProcessing">
+                                            <MudIcon Icon="@Icons.Material.Filled.NextPlan" Class="mr-1" />
+                                            Call Next
+                                        </MudButton>
+                                        <MudButton Variant="Variant.Filled" Color="Color.Success" Size="Size.Large" Disabled="_snapshot.Current is null || _isProcessing" OnClick="() => MarkDoneAsync(_snapshot.Current!.Id)">
+                                            <MudIcon Icon="@Icons.Material.Filled.Check" Class="mr-1" />
+                                            Done
+                                        </MudButton>
+                                        <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Large" Disabled="_snapshot.Current is null || _isProcessing" OnClick="() => MarkNoShowAsync(_snapshot.Current!.Id)">
+                                            <MudIcon Icon="@Icons.Material.Filled.PersonOff" Class="mr-1" />
+                                            No Show
+                                        </MudButton>
+                                    </MudStack>
+                                </MudStack>
+                            }
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudCard Elevation="2" Class="fade-in">
+                        <MudCardHeader>
+                            <CardHeaderContent>
+                                <MudText Typo="Typo.h6">Waiting Queue</MudText>
+                            </CardHeaderContent>
+                            <CardHeaderActions>
+                                <MudBadge Color="Color.Primary" Content="@(_snapshot?.Waiting.Count ?? 0)" Overlap="true" />
+                            </CardHeaderActions>
+                        </MudCardHeader>
+                        <MudCardContent>
+                            @if (_snapshot is null)
+                            {
+                                <MudSkeleton Height="40px" />
+                            }
+                            else if (_snapshot.Waiting.Count == 0)
+                            {
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary">No one waiting.</MudText>
+                            }
+                            else
+                            {
+                                <MudList Class="fade-in">
+                                    @foreach (var w in _snapshot.Waiting)
+                                    {
+                                        <MudListItem Class="fade-in">
+                                            <MudListItemText>
+                                                <MudText Typo="Typo.subtitle1" Class="font-weight-bold">@w.TicketNo</MudText>
+                                                <MudText Typo="Typo.caption" Color="Color.TextSecondary">Waiting @FormatDuration(w.CreatedAt)</MudText>
+                                            </MudListItemText>
+                                            <MudListItemIcon Color="Color.Secondary">@Icons.Material.Filled.Schedule</MudListItemIcon>
+                                            <MudListItemIcon>
+                                                <MudIconButton Icon="@Icons.Material.Filled.SkipNext" Color="Color.Secondary" Disabled="_isProcessing" OnClick="() => SkipAsync(w.Id)" />
+                                            </MudListItemIcon>
+                                        </MudListItem>
+                                    }
+                                </MudList>
+                            }
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            </MudGrid>
         }
-}
+    }
+</MudStack>
+
+<style>
+    .high-emphasis-card {
+        background: linear-gradient(135deg, rgba(63, 81, 181, 0.05), rgba(63, 81, 181, 0.12));
+    }
+
+    .fade-in {
+        animation: fadeIn 0.3s ease-in;
+    }
+
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+            transform: translateY(6px);
+        }
+
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+</style>
 
 @code {
-        private List<ServicePointDto> _points = new();
+    private List<ServicePointDto> _points = new();
 
-        private string? SelectedServicePointIdString;
-        private string? _selectionCandidateId;
-        private string? _selectionError;
-        private string? _accessMessage;
+    private string? SelectedServicePointIdString;
+    private string? _selectionCandidateId;
+    private string? _selectionError;
+    private string? _accessMessage;
 
-        private IJSObjectReference? _realtimeHandle;
-        private Guid? _connectedSpId;
-        private bool _realtimeReady;
+    private IJSObjectReference? _realtimeHandle;
+    private Guid? _connectedSpId;
+    private bool _realtimeReady;
 
-        private QueueSnapshotDto? _snapshot;
+    private QueueSnapshotDto? _snapshot;
 
-        private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
 
-        private bool HasSelectedServicePoint =>
-                Guid.TryParse(SelectedServicePointIdString, out var sp) && _points.Any(p => p.Id == sp);
+    private bool _isProcessing;
+    private Timer? _timer;
+    private DateTimeOffset _now = DateTimeOffset.UtcNow;
 
-        protected override async Task OnInitializedAsync()
+    private bool HasSelectedServicePoint =>
+        Guid.TryParse(SelectedServicePointIdString, out var sp) && _points.Any(p => p.Id == sp);
+
+    protected override async Task OnInitializedAsync()
+    {
+        _points = (await Mediator.Send(new GetMyServicePointsQuery())).ToList();
+
+        if (_points.Count == 0)
         {
-                _points = (await Mediator.Send(new GetMyServicePointsQuery())).ToList();
-
-                if (_points.Count == 0)
-                {
-                        _accessMessage = "You are not assigned to any service point. Please contact an administrator.";
-                        return;
-                }
-
-                if (_points.Count == 1)
-                {
-                        SelectedServicePointIdString = _points[0].Id.ToString();
-                        await RefreshAsync();
-                }
-                else
-                {
-                        _selectionCandidateId = _points[0].Id.ToString();
-                }
+            _accessMessage = "You are not assigned to any service point. Please contact an administrator.";
+            return;
         }
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
+        if (_points.Count == 1)
         {
-                if (firstRender)
-                {
-                        _realtimeReady = true;
-                        if (HasSelectedServicePoint)
-                                await ConnectToRealtimeAsync();
-                }
+            SelectedServicePointIdString = _points[0].Id.ToString();
+            await RefreshAsync();
+        }
+        else
+        {
+            _selectionCandidateId = _points[0].Id.ToString();
         }
 
-        private async Task OnServicePointChanged()
+        _timer = new Timer(1000) { AutoReset = true, Enabled = true };
+        _timer.Elapsed += (_, _) =>
         {
-                if (!HasSelectedServicePoint)
-                {
-                        _selectionError = "Invalid service point selection.";
-                        StateHasChanged();
-                        return;
-                }
+            _now = DateTimeOffset.UtcNow;
+            InvokeAsync(StateHasChanged);
+        };
+    }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _realtimeReady = true;
+            if (HasSelectedServicePoint)
                 await ConnectToRealtimeAsync();
-                await RefreshAsync();
+        }
+    }
+
+    private async Task OnServicePointChanged()
+    {
+        if (!HasSelectedServicePoint)
+        {
+            _selectionError = "Invalid service point selection.";
+            StateHasChanged();
+            return;
         }
 
-        private async Task ConfirmServicePointAsync()
+        await ConnectToRealtimeAsync();
+        await RefreshAsync();
+    }
+
+    private async Task ConfirmServicePointAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_selectionCandidateId) || !Guid.TryParse(_selectionCandidateId, out var candidate))
         {
-                if (string.IsNullOrWhiteSpace(_selectionCandidateId) || !Guid.TryParse(_selectionCandidateId, out var candidate))
-                {
-                        _selectionError = "Select a service point.";
-                        return;
-                }
-
-                if (!_points.Any(p => p.Id == candidate))
-                {
-                        _selectionError = "You cannot select this service point.";
-                        return;
-                }
-
-                SelectedServicePointIdString = candidate.ToString();
-                _selectionError = null;
-
-                await OnServicePointChanged();
+            _selectionError = "Select a service point.";
+            return;
         }
 
-        private async Task ConnectToRealtimeAsync()
+        if (!_points.Any(p => p.Id == candidate))
         {
-                if (!_realtimeReady) return;
-                if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
-                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
-                if (!_points.Any(p => p.Id == sp)) return;
+            _selectionError = "You cannot select this service point.";
+            return;
+        }
 
-                if (_connectedSpId == sp) return;
+        SelectedServicePointIdString = candidate.ToString();
+        _selectionError = null;
 
-		if (_realtimeHandle is not null)
-		{
-			try
-			{
-				await _realtimeHandle.InvokeVoidAsync("dispose");
-			}
-			catch
-			{
+        await OnServicePointChanged();
+    }
 
-			}
-			_realtimeHandle = null;
-			_connectedSpId = null;
-		}
+    private async Task ConnectToRealtimeAsync()
+    {
+        if (!_realtimeReady) return;
+        if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
+        if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+        if (!_points.Any(p => p.Id == sp)) return;
 
-		_realtimeHandle = await JS.InvokeAsync<IJSObjectReference>(
-				"qlineRealtime.connect", sp, DotNetObjectReference.Create(this));
-		_connectedSpId = sp;
-	}
+        if (_connectedSpId == sp) return;
 
-        private async Task RefreshAsync()
+        if (_realtimeHandle is not null)
         {
-                if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
-                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
-                if (!_points.Any(p => p.Id == sp)) return;
+            try
+            {
+                await _realtimeHandle.InvokeVoidAsync("dispose");
+            }
+            catch
+            {
 
-                await _refreshGate.WaitAsync();
-		try
-		{
-			_snapshot = await Mediator.Send(new GetQueueQuery(sp));
-			StateHasChanged();
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
+            }
+            _realtimeHandle = null;
+            _connectedSpId = null;
+        }
 
-	[JSInvokable]
-	public Task OnQueueUpdated() => RefreshAsync();
+        _realtimeHandle = await JS.InvokeAsync<IJSObjectReference>(
+                        "qlineRealtime.connect", sp, DotNetObjectReference.Create(this));
+        _connectedSpId = sp;
+    }
 
-	public async ValueTask DisposeAsync()
-	{
-		if (_realtimeHandle is not null)
-			await _realtimeHandle.InvokeVoidAsync("dispose");
-	}
+    private async Task RefreshAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedServicePointIdString)) return;
+        if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+        if (!_points.Any(p => p.Id == sp)) return;
 
-        private async Task CallNextAsync()
+        await _refreshGate.WaitAsync();
+        try
         {
-                if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
-                if (!_points.Any(p => p.Id == sp)) return;
-
-		await _refreshGate.WaitAsync();
-		try
-		{
-			await Mediator.Send(new CallNextCommand(sp));
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
-
-        private async Task MarkNoShowAsync(Guid id)
+            _snapshot = await Mediator.Send(new GetQueueQuery(sp));
+            StateHasChanged();
+        }
+        finally
         {
-                await _refreshGate.WaitAsync();
-                try
-                {
-			await Mediator.Send(new MarkNoShowCommand(id));
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
+            _refreshGate.Release();
+        }
+    }
 
-        private async Task MarkDoneAsync(Guid id)
-        {
-                await _refreshGate.WaitAsync();
-                try
-                {
-			await Mediator.Send(new MarkDoneCommand(id));
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
+    [JSInvokable]
+    public Task OnQueueUpdated() => RefreshAsync();
 
-        private async Task SkipAsync(Guid id)
+    public async ValueTask DisposeAsync()
+    {
+        _timer?.Stop();
+        _timer?.Dispose();
+
+        if (_realtimeHandle is not null)
+            await _realtimeHandle.InvokeVoidAsync("dispose");
+    }
+
+    private async Task CallNextAsync()
+    {
+        if (_isProcessing) return;
+        _isProcessing = true;
+
+        try
         {
-                await _refreshGate.WaitAsync();
-                try
-		{
-			await Mediator.Send(new SkipQueueEntryCommand(id));
-		}
-		finally
-		{
-			_refreshGate.Release();
-		}
-	}
+            if (!Guid.TryParse(SelectedServicePointIdString, out var sp)) return;
+            if (!_points.Any(p => p.Id == sp)) return;
+
+            await _refreshGate.WaitAsync();
+            try
+            {
+                await Mediator.Send(new CallNextCommand(sp));
+            }
+            finally
+            {
+                _refreshGate.Release();
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task MarkNoShowAsync(Guid id)
+    {
+        if (_isProcessing) return;
+        _isProcessing = true;
+
+        try
+        {
+            await _refreshGate.WaitAsync();
+            try
+            {
+                await Mediator.Send(new MarkNoShowCommand(id));
+            }
+            finally
+            {
+                _refreshGate.Release();
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task MarkDoneAsync(Guid id)
+    {
+        if (_isProcessing) return;
+        _isProcessing = true;
+
+        try
+        {
+            await _refreshGate.WaitAsync();
+            try
+            {
+                await Mediator.Send(new MarkDoneCommand(id));
+            }
+            finally
+            {
+                _refreshGate.Release();
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task SkipAsync(Guid id)
+    {
+        if (_isProcessing) return;
+        _isProcessing = true;
+
+        try
+        {
+            await _refreshGate.WaitAsync();
+            try
+            {
+                await Mediator.Send(new SkipQueueEntryCommand(id));
+            }
+            finally
+            {
+                _refreshGate.Release();
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private string FormatDuration(DateTimeOffset start)
+    {
+        var duration = _now - start;
+        if (duration < TimeSpan.Zero)
+            duration = TimeSpan.Zero;
+
+        return $"{(int)duration.TotalMinutes:00}:{duration.Seconds:00}";
+    }
+
+    private Color GetDurationColor(DateTimeOffset start)
+    {
+        var duration = _now - start;
+        if (duration.TotalMinutes < 5)
+            return Color.Success;
+        if (duration.TotalMinutes < 10)
+            return Color.Warning;
+        return Color.Error;
+    }
 }


### PR DESCRIPTION
## Summary
- rebuild the staff queue page layout with MudBlazor grid, cards, and list components
- add now-serving card with timer-based status coloring and action buttons with processing guards
- enhance waiting queue presentation with badges, fade-in animation, and skip controls

## Testing
- dotnet test QLine.sln *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1ec0cbcc832091b5659bfa4ce349)