### PR TITLE
Refine admin tables with MudBlazor components

### DIFF
--- a/QLine.Web/Components/Pages/Admin/ServicePoints.razor
+++ b/QLine.Web/Components/Pages/Admin/ServicePoints.razor
@@ -9,60 +9,77 @@
 @inject NavigationManager Nav
 @inject IMediator Mediator
 
-<h3>ServicePoints (Admin)</h3>
+<MudStack Spacing="3">
+    <MudText Typo="Typo.h4" Class="font-weight-bold">ServicePoints (Admin)</MudText>
 
-<ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+    <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
 
-<div class="card">
-	<h4>@(_editingId is null ? "Create" : "Edit")</h4>
-	<EditForm Model="this" OnValidSubmit="SaveAsync">
-		<DataAnnotationsValidator />
-		<div class="row">
-			<label>Name</label>
-			<input @bind="_formName" required />
-		</div>
-		<div class="row">
-			<label>Address</label>
-			<input @bind="_formAddress" required />
-		</div>
-		<div class="row">
-			<OpenHoursEditor @bind-Value="_formOpenHoursJson" @bind-Valid="_openHoursValid"/>
-		</div>
-		<div class="row">
-			<button type="submit" disabled="@IsSaveDisabled">Save</button>
-			@if (_editingId is not null)
-			{
-				<button type="button" @onclick="CancelEdit" style="margin-left:6px;">Cancel</button>
-			}
-		</div>
-	</EditForm>
-</div>
-
-<table>
-        <thead><tr><th>Name</th><th>Address</th><th></th></tr></thead>
-        <tbody>
-                @foreach (var sp in _list)
-                {
-                        <tr>
-                                <td>@sp.Name</td>
-                                <td>@sp.Address</td>
-                                <td>
-                                        <button @onclick="() => Edit(sp)">Edit</button>
-                                        <button @onclick="() => DeleteAsync(sp.Id)" style="margin-left:6px;">Delete</button>
-                                        <button @onclick="() => GoToServices(sp.Id)" style="margin-left:12px;">Services</button>
-                                        <button @onclick="() => OpenStaffModal(sp)" style="margin-left:12px;">
-                                                <i class="bi bi-people"></i> Staff
-                                        </button>
-                                </td>
-                        </tr>
-                }
-        </tbody>
-</table>
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="4">
+            <MudPaper Class="pa-4" Elevation="1">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">@(_editingId is null ? "Create" : "Edit")</MudText>
+                    <EditForm Model="this" OnValidSubmit="SaveAsync">
+                        <MudStack Spacing="2">
+                            <MudTextField @bind-Value="_formName" Label="Name" Required="true" />
+                            <MudTextField @bind-Value="_formAddress" Label="Address" Required="true" />
+                            <OpenHoursEditor @bind-Value="_formOpenHoursJson" @bind-Valid="_openHoursValid" />
+                            <MudStack Row="true" Spacing="1">
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Type="Submit" Disabled="@IsSaveDisabled">Save</MudButton>
+                                @if (_editingId is not null)
+                                {
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="CancelEdit">Cancel</MudButton>
+                                }
+                            </MudStack>
+                        </MudStack>
+                    </EditForm>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="8">
+            <MudTable @ref="_table"
+                      Items="FilteredServicePoints"
+                      Hover="true"
+                      Striped="true"
+                      SortLabel="Sort by">
+                <ToolBarContent>
+                    <MudText Typo="Typo.h6">Service Points</MudText>
+                    <MudSpacer />
+                    <MudTextField @bind-Value="_searchTerm"
+                                  Placeholder="Search service points"
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Filled.Search"
+                                  Immediate="true" />
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="sp => sp.Name">Name</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortLabel="Address" SortBy="sp => sp.Address">Address</MudTableSortLabel></MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">@context.Name</MudTd>
+                    <MudTd DataLabel="Address">@context.Address</MudTd>
+                    <MudTd DataLabel="Actions">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => Edit(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
+                        <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="() => GoToServices(context.Id)">Services</MudButton>
+                        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => OpenStaffModal(context)">
+                            <MudIcon Icon="@Icons.Material.Filled.People" Class="mr-1" />Staff
+                        </MudButton>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+            <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
+        </MudItem>
+    </MudGrid>
+</MudStack>
 
 <StaffAssignmentModal Visible="@_showStaffModal" ServicePointId="@_staffModalServicePointId" ServicePointName="@_staffModalServicePointName" OnClose="CloseStaffModal" />
 
 @code {
     private List<ServicePointDto> _list = new();
+    private MudTable<ServicePointDto>? _table;
+    private string _searchTerm = string.Empty;
 
 	private Guid? _editingId;
 	private string _formName = "";
@@ -80,11 +97,17 @@
 	private static string DefaultOpenHoursJson() =>
 		"""{ "monday":{"open":true, "start":"07:30","end":"16:00"}, "tuesday":{"open":true, "start":"07:30","end":"16:00"}, "wednesday":{"open":true, "start":"07:30","end":"16:00"}, "thursday":{"open":true, "start":"07:30","end":"16:00"}, "friday":{"open":true, "start":"07:30","end":"16:00"}, "saturday":{"open":false, "start":"07:30","end":"16:00"}, "sunday":{"open":false, "start":"07:30","end":"16:00"} }""";
 
-	private bool IsSaveDisabled =>
-		string.IsNullOrWhiteSpace(_formName) ||
-		string.IsNullOrWhiteSpace(_formAddress) ||
-		string.IsNullOrWhiteSpace(_formOpenHoursJson) ||
-		!_openHoursValid;
+    private bool IsSaveDisabled =>
+            string.IsNullOrWhiteSpace(_formName) ||
+            string.IsNullOrWhiteSpace(_formAddress) ||
+            string.IsNullOrWhiteSpace(_formOpenHoursJson) ||
+            !_openHoursValid;
+
+    private IEnumerable<ServicePointDto> FilteredServicePoints =>
+        _list.Where(sp =>
+            string.IsNullOrWhiteSpace(_searchTerm) ||
+            sp.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
+            sp.Address.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
 	protected override async Task OnInitializedAsync() => await LoadAsync();
 

--- a/QLine.Web/Components/Pages/Admin/Services.razor
+++ b/QLine.Web/Components/Pages/Admin/Services.razor
@@ -7,49 +7,85 @@
 @using QLine.Application.Features.Admin.Services.Commands
 @inject IMediator Mediator
 
-<h3>Services (Admin)</h3>
+<MudStack Spacing="3">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+        <MudIcon Icon="@Icons.Material.Filled.DesignServices" Color="Color.Primary" />
+        <MudText Typo="Typo.h4" Class="font-weight-bold">Services (Admin)</MudText>
+    </MudStack>
 
-<p><a href="/admin/servicepoints">Back to Service Points</a></p>
+    <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/admin/servicepoints">
+        <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Class="mr-1" />Back to Service Points
+    </MudButton>
 
-<div style="margin-bottom:12px; padding:10px; border:1px solid #eee; border-radius: 6px;">
-        <h4>@(_editingId is null ? "Create" : "Edit")</h4>
-        <div><label>Name</label><br /><input @bind="_name" /></div>
-        <div><label>Duration (min)</label><br /><input type="number" @bind="_dur" /></div>
-        <div><label>Buffer (min)</label><br /><input type="number" @bind="_buf" /></div>
-        <button @onclick="SaveAsync">Save</button>
-        @if (_editingId is not null)
-        {
-                <button @onclick="CancelEdit" style="margin-left:6px;">Cancel</button>
-        }
-</div>
-
-<table>
-        <thead>
-                <tr><th>Name</th><th>Duration</th><th>Buffer</th><th></th></tr>
-        </thead>
-        <tbody>
-                @foreach (var s in _list)
-                {
-                        <tr>
-                                <td>@s.Name</td><td>@s.DurationMin</td><td>@s.BufferMin</td>
-                                <td>
-                                        <button @onclick="() => Edit(s)">Edit</button>
-                                        <button @onclick="() => DeleteAsync(s.Id)" style="margin-left:6px;">Delete</button>
-				</td>
-			</tr>
-		}
-	</tbody>
-</table>
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="4">
+            <MudPaper Class="pa-4" Elevation="1">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.h6">@(_editingId is null ? "Create" : "Edit")</MudText>
+                    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
+                    <MudNumericField @bind-Value="_dur" Label="Duration (min)" Required="true" />
+                    <MudNumericField @bind-Value="_buf" Label="Buffer (min)" Required="true" />
+                    <MudStack Row="true" Spacing="1">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveAsync">Save</MudButton>
+                        @if (_editingId is not null)
+                        {
+                            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="CancelEdit">Cancel</MudButton>
+                        }
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="8">
+            <MudTable @ref="_table"
+                      Items="FilteredServices"
+                      Hover="true"
+                      Striped="true"
+                      SortLabel="Sort by">
+                <ToolBarContent>
+                    <MudText Typo="Typo.h6">Services</MudText>
+                    <MudSpacer />
+                    <MudTextField @bind-Value="_searchTerm"
+                                  Placeholder="Search services"
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Filled.Search"
+                                  Immediate="true" />
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="s => s.Name">Name</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortLabel="Duration" SortBy="s => s.DurationMin">Duration</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortLabel="Buffer" SortBy="s => s.BufferMin">Buffer</MudTableSortLabel></MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">@context.Name</MudTd>
+                    <MudTd DataLabel="Duration">@context.DurationMin min</MudTd>
+                    <MudTd DataLabel="Buffer">@context.BufferMin min</MudTd>
+                    <MudTd DataLabel="Actions">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => Edit(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+            <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
+        </MudItem>
+    </MudGrid>
+</MudStack>
 
 @code {
     [Parameter] public Guid ServicePointId { get; set; }
 
         private List<ServiceDto> _list = new();
+        private MudTable<ServiceDto>? _table;
+        private string _searchTerm = string.Empty;
 
         private Guid? _editingId;
         private string _name = "";
         private int _dur = 15;
         private int _buf = 5;
+
+        private IEnumerable<ServiceDto> FilteredServices =>
+            _list.Where(s => string.IsNullOrWhiteSpace(_searchTerm)
+                || s.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
 	protected override async Task OnInitializedAsync() => await LoadAsync();
 

--- a/QLine.Web/Components/Pages/Admin/Users.razor
+++ b/QLine.Web/Components/Pages/Admin/Users.razor
@@ -10,60 +10,76 @@
 @inject IMediator Mediator
 @inject ICurrentUser CurrentUser
 
-<h3>Users</h3>
+<MudStack Spacing="3">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+        <MudIcon Icon="@Icons.Material.Filled.People" Color="Color.Primary" />
+        <MudText Typo="Typo.h4" Class="font-weight-bold">Users</MudText>
+    </MudStack>
 
-@if (_loading)
-{
-    <p>Loading users...</p>
-}
-else if (_users.Count == 0)
-{
-    <p>No users found.</p>
-}
-else
-{
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Email</th>
-                <th>Role</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var user in _users)
-            {
-                <tr>
-                    <td>@user.Name</td>
-                    <td>@user.Email</td>
-                    <td>@user.Role</td>
-                    <td>
-                        @if (user.Role == nameof(UserRole.Client))
+    @if (_loading)
+    {
+        <MudProgressCircular Color="Color.Primary" />
+    }
+    else
+    {
+        <MudPaper Class="pa-3" Elevation="1">
+            <MudTable @ref="_table"
+                      Items="FilteredUsers"
+                      Hover="true"
+                      Striped="true"
+                      SortLabel="Sort by"
+                      Dense="true">
+                <ToolBarContent>
+                    <MudText Typo="Typo.h6">All Users</MudText>
+                    <MudSpacer />
+                    <MudTextField @bind-Value="_searchTerm"
+                                  Placeholder="Search users"
+                                  Adornment="Adornment.Start"
+                                  AdornmentIcon="@Icons.Material.Filled.Search"
+                                  Immediate="true" />
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="u => u.Name">Name</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortLabel="Email" SortBy="u => u.Email">Email</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel SortLabel="Role" SortBy="u => u.Role">Role</MudTableSortLabel></MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">@context.Name</MudTd>
+                    <MudTd DataLabel="Email">@context.Email</MudTd>
+                    <MudTd DataLabel="Role">@context.Role</MudTd>
+                    <MudTd DataLabel="Actions">
+                        @if (context.Role == nameof(UserRole.Client))
                         {
-                            <button class="btn btn-success btn-sm"
-                                    disabled="@IsCurrentUser(user.Id)"
-                                    @onclick="() => UpdateRole(user.Id, UserRole.Staff)">
-                                Promote to Staff
-                            </button>
+                            <MudButton Variant="Variant.Filled" Color="Color.Success" Size="Size.Small"
+                                       Disabled="@IsCurrentUser(context.Id)"
+                                       OnClick="() => UpdateRole(context.Id, UserRole.Staff)">
+                                <MudIcon Icon="@Icons.Material.Filled.Upgrade" Class="mr-1" />Promote to Staff
+                            </MudButton>
                         }
-                        else if (user.Role == nameof(UserRole.Staff))
+                        else if (context.Role == nameof(UserRole.Staff))
                         {
-                            <button class="btn btn-warning btn-sm"
-                                    disabled="@IsCurrentUser(user.Id)"
-                                    @onclick="() => UpdateRole(user.Id, UserRole.Client)">
-                                Demote to Client
-                            </button>
+                            <MudButton Variant="Variant.Outlined" Color="Color.Warning" Size="Size.Small"
+                                       Disabled="@IsCurrentUser(context.Id)"
+                                       OnClick="() => UpdateRole(context.Id, UserRole.Client)">
+                                <MudIcon Icon="@Icons.Material.Filled.South" Class="mr-1" />Demote to Client
+                            </MudButton>
                         }
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-}
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">No users found.</MudText>
+                </NoRecordsContent>
+            </MudTable>
+            <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
+        </MudPaper>
+    }
+</MudStack>
 
 @code {
     private readonly List<UserDto> _users = new();
+    private MudTable<UserDto>? _table;
+    private string _searchTerm = string.Empty;
     private bool _loading = true;
     private Guid? _currentUserId;
 
@@ -80,6 +96,12 @@ else
         _users.AddRange(await Mediator.Send(new GetAllUsersQuery()));
         _loading = false;
     }
+
+    private IEnumerable<UserDto> FilteredUsers =>
+        _users.Where(u => string.IsNullOrWhiteSpace(_searchTerm)
+            || u.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase)
+            || u.Email.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase)
+            || u.Role.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
     private async Task UpdateRole(Guid userId, UserRole newRole)
     {


### PR DESCRIPTION
## Summary
- convert admin service points, services, and users pages to MudTable layouts with search toolbars, hover/striped styling, and sorting labels
- add responsive MudGrid/MudStack layouts, icon-based action buttons, and pagination via MudTablePager
- keep forms within updated MudBlazor cards for consistent editing experiences

## Testing
- `dotnet test QLine.sln` *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3998e0108320b583b97b969111e7)