### PR TITLE
Add dialog-based create flows for admin lists

### DIFF
--- a/QLine.Web/Components/Pages/Admin/ServiceFormDialog.razor
+++ b/QLine.Web/Components/Pages/Admin/ServiceFormDialog.razor
@@ -1,0 +1,66 @@
+@using MediatR
+@using QLine.Application.Features.Admin.Services.Commands
+@inject IMediator Mediator
+
+<MudDialog MaxWidth="MaxWidth.Small" CloseOnEscapeKey="true">
+    <DialogContent>
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">@(_serviceId is null ? "Create Service" : "Edit Service")</MudText>
+            <EditForm Model="this" OnValidSubmit="SaveAsync">
+                <MudStack Spacing="2">
+                    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
+                    <MudNumericField @bind-Value="_duration" Label="Duration (min)" Required="true" Min="1" Immediate="true" />
+                    <MudNumericField @bind-Value="_buffer" Label="Buffer (min)" Required="true" Min="0" Immediate="true" />
+                </MudStack>
+            </EditForm>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="IsSaveDisabled" OnClick="SaveAsync">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Parameter] public Guid? ServiceId { get; set; }
+    [Parameter] public Guid ServicePointId { get; set; }
+    [Parameter] public string? Name { get; set; }
+    [Parameter] public int? Duration { get; set; }
+    [Parameter] public int? Buffer { get; set; }
+
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
+
+    private Guid? _serviceId;
+    private Guid _servicePointId;
+    private string _name = string.Empty;
+    private int? _duration;
+    private int? _buffer;
+
+    protected override void OnInitialized()
+    {
+        _serviceId = ServiceId;
+        _servicePointId = ServicePointId;
+        _name = Name ?? string.Empty;
+        _duration = Duration ?? 15;
+        _buffer = Buffer ?? 5;
+    }
+
+    private bool IsSaveDisabled => string.IsNullOrWhiteSpace(_name) || !_duration.HasValue || !_buffer.HasValue;
+
+    private async Task SaveAsync()
+    {
+        if (IsSaveDisabled) return;
+
+        await Mediator.Send(new UpsertServiceCommand(
+            Id: _serviceId,
+            ServicePointId: _servicePointId,
+            Name: _name.Trim(),
+            DurationMin: _duration!.Value,
+            BufferMin: _buffer!.Value
+        ));
+
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/QLine.Web/Components/Pages/Admin/ServicePointFormDialog.razor
+++ b/QLine.Web/Components/Pages/Admin/ServicePointFormDialog.razor
@@ -1,0 +1,84 @@
+@using MediatR
+@using QLine.Application.Features.Admin.ServicePoints.Commands
+@using QLine.Application.DTO
+@inject IMediator Mediator
+
+<MudDialog MaxWidth="MaxWidth.Medium" CloseOnEscapeKey="true">
+    <DialogContent>
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h6">@(_servicePointId is null ? "Create Service Point" : "Edit Service Point")</MudText>
+            <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+            <EditForm Model="this" OnValidSubmit="SaveAsync">
+                <MudStack Spacing="2">
+                    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
+                    <MudTextField @bind-Value="_address" Label="Address" Required="true" />
+                    <OpenHoursEditor @bind-Value="_openHoursJson" @bind-Valid="_openHoursValid" />
+                </MudStack>
+            </EditForm>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="IsSaveDisabled" OnClick="SaveAsync">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Parameter] public Guid? ServicePointId { get; set; }
+    [Parameter] public string? Name { get; set; }
+    [Parameter] public string? Address { get; set; }
+    [Parameter] public string? OpenHoursJson { get; set; }
+
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
+
+    private Guid? _servicePointId;
+    private string _name = string.Empty;
+    private string _address = string.Empty;
+    private string? _openHoursJson;
+    private bool _openHoursValid = true;
+
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+
+    protected override void OnInitialized()
+    {
+        _servicePointId = ServicePointId;
+        _name = Name ?? string.Empty;
+        _address = Address ?? string.Empty;
+        _openHoursJson = string.IsNullOrWhiteSpace(OpenHoursJson) ? DefaultOpenHoursJson() : OpenHoursJson;
+    }
+
+    private bool IsSaveDisabled =>
+        string.IsNullOrWhiteSpace(_name) ||
+        string.IsNullOrWhiteSpace(_address) ||
+        string.IsNullOrWhiteSpace(_openHoursJson) ||
+        !_openHoursValid;
+
+    private async Task SaveAsync()
+    {
+        if (IsSaveDisabled) return;
+
+        try
+        {
+            _errorMessage = null; _errorDetails = null;
+
+            await Mediator.Send(new UpsertServicePointCommand(
+                Id: _servicePointId,
+                Name: _name.Trim(),
+                Address: _address.Trim(),
+                OpenHoursJson: _openHoursJson ?? DefaultOpenHoursJson()
+            ));
+
+            MudDialog.Close(DialogResult.Ok(true));
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string DefaultOpenHoursJson() =>
+        """{ "monday":{"open":true, "start":"07:30","end":"16:00"}, "tuesday":{"open":true, "start":"07:30","end":"16:00"}, "wednesday":{"open":true, "start":"07:30","end":"16:00"}, "thursday":{"open":true, "start":"07:30","end":"16:00"}, "friday":{"open":true, "start":"07:30","end":"16:00"}, "saturday":{"open":false, "start":"07:30","end":"16:00"}, "sunday":{"open":false,"start":"07:30","end":"16:00"} }""";
+}

--- a/QLine.Web/Components/Pages/Admin/ServicePoints.razor
+++ b/QLine.Web/Components/Pages/Admin/ServicePoints.razor
@@ -8,70 +8,50 @@
 @using QLine.Web.Components.OpenHours
 @inject NavigationManager Nav
 @inject IMediator Mediator
+@inject IDialogService DialogService
 
 <MudStack Spacing="3">
     <MudText Typo="Typo.h4" Class="font-weight-bold">ServicePoints (Admin)</MudText>
 
     <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
 
-    <MudGrid Spacing="3">
-        <MudItem xs="12" md="4">
-            <MudPaper Class="pa-4" Elevation="1">
-                <MudStack Spacing="2">
-                    <MudText Typo="Typo.h6">@(_editingId is null ? "Create" : "Edit")</MudText>
-                    <EditForm Model="this" OnValidSubmit="SaveAsync">
-                        <MudStack Spacing="2">
-                            <MudTextField @bind-Value="_formName" Label="Name" Required="true" />
-                            <MudTextField @bind-Value="_formAddress" Label="Address" Required="true" />
-                            <OpenHoursEditor @bind-Value="_formOpenHoursJson" @bind-Valid="_openHoursValid" />
-                            <MudStack Row="true" Spacing="1">
-                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Type="Submit" Disabled="@IsSaveDisabled">Save</MudButton>
-                                @if (_editingId is not null)
-                                {
-                                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="CancelEdit">Cancel</MudButton>
-                                }
-                            </MudStack>
-                        </MudStack>
-                    </EditForm>
-                </MudStack>
-            </MudPaper>
-        </MudItem>
-        <MudItem xs="12" md="8">
-            <MudTable @ref="_table"
-                      Items="FilteredServicePoints"
-                      Hover="true"
-                      Striped="true"
-                      SortLabel="Sort by">
-                <ToolBarContent>
-                    <MudText Typo="Typo.h6">Service Points</MudText>
-                    <MudSpacer />
-                    <MudTextField @bind-Value="_searchTerm"
-                                  Placeholder="Search service points"
-                                  Adornment="Adornment.Start"
-                                  AdornmentIcon="@Icons.Material.Filled.Search"
-                                  Immediate="true" />
-                </ToolBarContent>
-                <HeaderContent>
-                    <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="sp => sp.Name">Name</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="Address" SortBy="sp => sp.Address">Address</MudTableSortLabel></MudTh>
-                    <MudTh></MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Name">@context.Name</MudTd>
-                    <MudTd DataLabel="Address">@context.Address</MudTd>
-                    <MudTd DataLabel="Actions">
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => Edit(context)" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
-                        <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="() => GoToServices(context.Id)">Services</MudButton>
-                        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => OpenStaffModal(context)">
-                            <MudIcon Icon="@Icons.Material.Filled.People" Class="mr-1" />Staff
-                        </MudButton>
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
-            <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
-        </MudItem>
-    </MudGrid>
+    <MudPaper Class="pa-4 mb-4" Elevation="1">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudText Typo="Typo.h6">Service Points</MudText>
+            <MudFab Color="Color.Primary" Icon="@Icons.Material.Filled.Add" Size="Size.Small" Label="Create New" OnClick="OpenCreateDialog" />
+            <MudSpacer />
+            <MudTextField @bind-Value="_searchTerm"
+                          Placeholder="Search service points"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Immediate="true" />
+        </MudStack>
+    </MudPaper>
+
+    <MudTable @ref="_table"
+              Items="FilteredServicePoints"
+              Hover="true"
+              Striped="true"
+              SortLabel="Sort by">
+        <HeaderContent>
+            <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="sp => sp.Name">Name</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel SortLabel="Address" SortBy="sp => sp.Address">Address</MudTableSortLabel></MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd DataLabel="Address">@context.Address</MudTd>
+            <MudTd DataLabel="Actions">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => OpenEditDialog(context)" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
+                <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="() => GoToServices(context.Id)">Services</MudButton>
+                <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => OpenStaffModal(context)">
+                    <MudIcon Icon="@Icons.Material.Filled.People" Class="mr-1" />Staff
+                </MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+    <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
 </MudStack>
 
 <StaffAssignmentModal Visible="@_showStaffModal" ServicePointId="@_staffModalServicePointId" ServicePointName="@_staffModalServicePointName" OnClose="CloseStaffModal" />
@@ -81,12 +61,6 @@
     private MudTable<ServicePointDto>? _table;
     private string _searchTerm = string.Empty;
 
-	private Guid? _editingId;
-	private string _formName = "";
-	private string _formAddress = "";
-	private string? _formOpenHoursJson = DefaultOpenHoursJson();
-	private bool _openHoursValid = true;
-
         private string? _errorMessage;
         private List<string>? _errorDetails;
 
@@ -94,79 +68,50 @@
         private Guid _staffModalServicePointId;
         private string? _staffModalServicePointName;
 
-	private static string DefaultOpenHoursJson() =>
-		"""{ "monday":{"open":true, "start":"07:30","end":"16:00"}, "tuesday":{"open":true, "start":"07:30","end":"16:00"}, "wednesday":{"open":true, "start":"07:30","end":"16:00"}, "thursday":{"open":true, "start":"07:30","end":"16:00"}, "friday":{"open":true, "start":"07:30","end":"16:00"}, "saturday":{"open":false, "start":"07:30","end":"16:00"}, "sunday":{"open":false, "start":"07:30","end":"16:00"} }""";
-
-    private bool IsSaveDisabled =>
-            string.IsNullOrWhiteSpace(_formName) ||
-            string.IsNullOrWhiteSpace(_formAddress) ||
-            string.IsNullOrWhiteSpace(_formOpenHoursJson) ||
-            !_openHoursValid;
-
-    private IEnumerable<ServicePointDto> FilteredServicePoints =>
+        private IEnumerable<ServicePointDto> FilteredServicePoints =>
         _list.Where(sp =>
             string.IsNullOrWhiteSpace(_searchTerm) ||
             sp.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
             sp.Address.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
-	protected override async Task OnInitializedAsync() => await LoadAsync();
+        protected override async Task OnInitializedAsync() => await LoadAsync();
 
-	private async Task LoadAsync()
-	{
+        private async Task LoadAsync()
+        {
             try
             {
                     _list = (await Mediator.Send(new GetServicePointsQuery())).ToList();
             }
-		catch (Exception ex)
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
-	}
+                catch (Exception ex)
+                {
+                        (_errorMessage, _errorDetails) = ex.ToUserMessage();
+                }
+        }
 
-	private void Edit(ServicePointDto sp)
-	{
-		_editingId = sp.Id;
-		_formName = sp.Name;
-		_formAddress = sp.Address;
-		_formOpenHoursJson = string.IsNullOrWhiteSpace(sp.OpenHoursJson)
-			? DefaultOpenHoursJson()
-			: sp.OpenHoursJson;
-		_openHoursValid = true;
-	}
+        private async Task OpenCreateDialog() => await OpenDialogAsync(null);
 
-	private void CancelEdit()
-	{
-		_editingId = null;
-		_formName = ""; 
-		_formAddress = "";
-		_formOpenHoursJson = DefaultOpenHoursJson();
-		_openHoursValid = true;
-		_errorMessage = null; _errorDetails = null;
-	}
+        private async Task OpenEditDialog(ServicePointDto sp) => await OpenDialogAsync(sp);
 
-	private async Task SaveAsync()
-	{
-		if (IsSaveDisabled) return;
+        private async Task OpenDialogAsync(ServicePointDto? sp)
+        {
+                var parameters = new DialogParameters
+                {
+                        { nameof(ServicePointFormDialog.ServicePointId), sp?.Id },
+                        { nameof(ServicePointFormDialog.Name), sp?.Name },
+                        { nameof(ServicePointFormDialog.Address), sp?.Address },
+                        { nameof(ServicePointFormDialog.OpenHoursJson), sp?.OpenHoursJson }
+                };
 
-		try
-		{
-			_errorMessage = null; _errorDetails = null;
+                var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true };
+                var dialog = DialogService.Show<ServicePointFormDialog>(sp is null ? "Create Service Point" : "Edit Service Point", parameters, options);
+                var result = await dialog.Result;
 
-                        await Mediator.Send(new UpsertServicePointCommand(
-                                Id: _editingId,
-                                Name: _formName.Trim(),
-                                Address: _formAddress.Trim(),
-                                OpenHoursJson: _formOpenHoursJson ?? DefaultOpenHoursJson()
-                        ));
-			CancelEdit();
-			await LoadAsync();
-			StateHasChanged();
-		}
-		catch (Exception ex)
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
-	}
+                if (!result.Cancelled)
+                {
+                        await LoadAsync();
+                        StateHasChanged();
+                }
+        }
 
         private async Task DeleteAsync(Guid id)
         {
@@ -195,6 +140,6 @@
                 _showStaffModal = false;
         }
 
-		private void GoToServices(Guid id)
-			=> Nav.NavigateTo($"/admin/services/{id}");
+                private void GoToServices(Guid id)
+                        => Nav.NavigateTo($"/admin/services/{id}");
 }

--- a/QLine.Web/Components/Pages/Admin/Services.razor
+++ b/QLine.Web/Components/Pages/Admin/Services.razor
@@ -6,6 +6,7 @@
 @using QLine.Application.Features.Admin.Queries
 @using QLine.Application.Features.Admin.Services.Commands
 @inject IMediator Mediator
+@inject IDialogService DialogService
 
 <MudStack Spacing="3">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
@@ -17,58 +18,41 @@
         <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Class="mr-1" />Back to Service Points
     </MudButton>
 
-    <MudGrid Spacing="3">
-        <MudItem xs="12" md="4">
-            <MudPaper Class="pa-4" Elevation="1">
-                <MudStack Spacing="2">
-                    <MudText Typo="Typo.h6">@(_editingId is null ? "Create" : "Edit")</MudText>
-                    <MudTextField @bind-Value="_name" Label="Name" Required="true" />
-                    <MudNumericField @bind-Value="_dur" Label="Duration (min)" Required="true" />
-                    <MudNumericField @bind-Value="_buf" Label="Buffer (min)" Required="true" />
-                    <MudStack Row="true" Spacing="1">
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveAsync">Save</MudButton>
-                        @if (_editingId is not null)
-                        {
-                            <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="CancelEdit">Cancel</MudButton>
-                        }
-                    </MudStack>
-                </MudStack>
-            </MudPaper>
-        </MudItem>
-        <MudItem xs="12" md="8">
-            <MudTable @ref="_table"
-                      Items="FilteredServices"
-                      Hover="true"
-                      Striped="true"
-                      SortLabel="Sort by">
-                <ToolBarContent>
-                    <MudText Typo="Typo.h6">Services</MudText>
-                    <MudSpacer />
-                    <MudTextField @bind-Value="_searchTerm"
-                                  Placeholder="Search services"
-                                  Adornment="Adornment.Start"
-                                  AdornmentIcon="@Icons.Material.Filled.Search"
-                                  Immediate="true" />
-                </ToolBarContent>
-                <HeaderContent>
-                    <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="s => s.Name">Name</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="Duration" SortBy="s => s.DurationMin">Duration</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel SortLabel="Buffer" SortBy="s => s.BufferMin">Buffer</MudTableSortLabel></MudTh>
-                    <MudTh></MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Name">@context.Name</MudTd>
-                    <MudTd DataLabel="Duration">@context.DurationMin min</MudTd>
-                    <MudTd DataLabel="Buffer">@context.BufferMin min</MudTd>
-                    <MudTd DataLabel="Actions">
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => Edit(context)" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
-            <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
-        </MudItem>
-    </MudGrid>
+    <MudPaper Class="pa-4 mb-4" Elevation="1">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudText Typo="Typo.h6">Services</MudText>
+            <MudFab Color="Color.Primary" Icon="@Icons.Material.Filled.Add" Size="Size.Small" Label="Create New" OnClick="OpenCreateDialog" />
+            <MudSpacer />
+            <MudTextField @bind-Value="_searchTerm"
+                          Placeholder="Search services"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Immediate="true" />
+        </MudStack>
+    </MudPaper>
+
+    <MudTable @ref="_table"
+              Items="FilteredServices"
+              Hover="true"
+              Striped="true"
+              SortLabel="Sort by">
+        <HeaderContent>
+            <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortLabel="Name" SortBy="s => s.Name">Name</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel SortLabel="Duration" SortBy="s => s.DurationMin">Duration</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel SortLabel="Buffer" SortBy="s => s.BufferMin">Buffer</MudTableSortLabel></MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd DataLabel="Duration">@context.DurationMin min</MudTd>
+            <MudTd DataLabel="Buffer">@context.BufferMin min</MudTd>
+            <MudTd DataLabel="Actions">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => OpenEditDialog(context)" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+    <MudTablePager PageSizeOptions="new int[] { 5, 10, 20 }" Table="_table" />
 </MudStack>
 
 @code {
@@ -78,54 +62,45 @@
         private MudTable<ServiceDto>? _table;
         private string _searchTerm = string.Empty;
 
-        private Guid? _editingId;
-        private string _name = "";
-        private int _dur = 15;
-        private int _buf = 5;
-
         private IEnumerable<ServiceDto> FilteredServices =>
             _list.Where(s => string.IsNullOrWhiteSpace(_searchTerm)
                 || s.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
-	protected override async Task OnInitializedAsync() => await LoadAsync();
+        protected override async Task OnInitializedAsync() => await LoadAsync();
 
-	private async Task LoadAsync()
-		=> _list = (await Mediator.Send(new GetServicesForServicePointQuery(ServicePointId))).ToList();
+        private async Task LoadAsync()
+                => _list = (await Mediator.Send(new GetServicesForServicePointQuery(ServicePointId))).ToList();
 
-        private void Edit(ServiceDto s)
+        private async Task OpenCreateDialog() => await OpenDialogAsync(null);
+
+        private async Task OpenEditDialog(ServiceDto s) => await OpenDialogAsync(s);
+
+        private async Task OpenDialogAsync(ServiceDto? service)
         {
-                _editingId = s.Id;
-                _name = s.Name;
-                _dur = s.DurationMin;
-                _buf = s.BufferMin;
+                var parameters = new DialogParameters
+                {
+                        { nameof(ServiceFormDialog.ServiceId), service?.Id },
+                        { nameof(ServiceFormDialog.ServicePointId), ServicePointId },
+                        { nameof(ServiceFormDialog.Name), service?.Name },
+                        { nameof(ServiceFormDialog.Duration), service?.DurationMin },
+                        { nameof(ServiceFormDialog.Buffer), service?.BufferMin }
+                };
+
+                var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+                var dialog = DialogService.Show<ServiceFormDialog>(service is null ? "Create Service" : "Edit Service", parameters, options);
+                var result = await dialog.Result;
+
+                if (!result.Cancelled)
+                {
+                        await LoadAsync();
+                        StateHasChanged();
+                }
         }
 
-        private void CancelEdit()
+        private async Task DeleteAsync(Guid id)
         {
-                _editingId = null;
-                _name = "";
-                _dur = 15;
-                _buf = 5;
-        }
-
-        private async Task SaveAsync()
-        {
-                await Mediator.Send(new UpsertServiceCommand(
-                        Id: _editingId,
-                        ServicePointId: ServicePointId,
-                        Name: _name,
-                        DurationMin: _dur,
-                        BufferMin: _buf
-                ));
-                CancelEdit();
+                await Mediator.Send(new DeleteServiceCommand(id));
                 await LoadAsync();
-		StateHasChanged();
-	}
-
-	private async Task DeleteAsync(Guid id)
-	{
-		await Mediator.Send(new DeleteServiceCommand(id));
-		await LoadAsync();
-		StateHasChanged();
-	}
+                StateHasChanged();
+        }
 }


### PR DESCRIPTION
## Summary
- add MudDialog forms for creating and editing service points and services
- refresh admin lists after dialog submissions and replace inline forms with a create FAB
- introduce reusable dialog components for service point and service forms

## Testing
- dotnet build QLine.Web/QLine.Web.csproj *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3bb51ba08320806723c89ae66c5c)