### PR TITLE
Revamp open hours editor and add staff tooltip

### DIFF
--- a/QLine.Web/Components/OpenHours/OpenHoursEditor.razor
+++ b/QLine.Web/Components/OpenHours/OpenHoursEditor.razor
@@ -1,240 +1,259 @@
-﻿@using System.Text.Json
+@using System.Text.Json
 @using System.Text.Json.Nodes
 
-<div class="oh-card">
-	<h4>OPENING HOURS</h4>
+<MudPaper Class="oh-card" Elevation="1">
+    <MudText Typo="Typo.h6" Class="font-weight-bold mb-2">Opening Hours</MudText>
 
-	<table class="oh-table">
-		<thead>
-			<tr>
-				<th>Day</th>
-				<th>Open?</th>
-				<th>Opening Hrs</th>
-				<th>Closing Hrs</th>
-			</tr>
-		</thead>
-		<tbody>
-			@foreach (var row in Rows)
-			{
-				<tr>
-					<td class="oh-day">@row.Label</td>
-					<td class="oh-open">
-						<input type="checkbox" @bind="row.Open" @bind:after="() => OnRowChanged(row)" />
-					</td>
-					<td>
-						<input	type="time"
-								@bind="row.Opening"
-								@bind:after="() => OnRowChanged(row)"
-								disabled="@(!row.Open)" />
-					</td>
-					<td>
-						<input	type="time"
-								@bind="row.Closing"
-								@bind:after="() => OnRowChanged(row)"
-								disabled="@(!row.Open)" />
-						@if (!string.IsNullOrEmpty(row.Error))
-						{
-							<div class="oh-error">@row.Error</div>
-						}
-					</td>
-				</tr>
-			}
-		</tbody>
-	</table>
-</div>
+    <MudGrid Class="oh-grid" Spacing="2">
+        @foreach (var row in Rows)
+        {
+            <MudItem xs="12">
+                <MudGrid AlignItems="AlignItems.Center" Class="oh-row" Spacing="2">
+                    <MudItem xs="12" sm="3">
+                        <MudText Typo="Typo.subtitle2" Class="oh-day">@row.Label</MudText>
+                    </MudItem>
+                    <MudItem xs="12" sm="3">
+                        <MudSwitch Color="Color.Primary"
+                                   Checked="row.Open"
+                                   CheckedChanged="value => OnOpenChanged(row, value)"
+                                   Class="oh-open"
+                                   DisableRipple="true"
+                                   Label="Open" />
+                    </MudItem>
+                    <MudItem xs="12" sm="3">
+                        <MudTimePicker Class="oh-picker"
+                                       AmPm="false"
+                                       Time="row.Opening"
+                                       TimeChanged="time => OnTimeChanged(row, time, true)"
+                                       Disabled="@(!row.Open)"
+                                       MinuteInterval="5"
+                                       Label="Start" />
+                    </MudItem>
+                    <MudItem xs="12" sm="3">
+                        <MudTimePicker Class="oh-picker"
+                                       AmPm="false"
+                                       Time="row.Closing"
+                                       TimeChanged="time => OnTimeChanged(row, time, false)"
+                                       Disabled="@(!row.Open)"
+                                       MinuteInterval="5"
+                                       Label="End" />
+                        @if (!string.IsNullOrEmpty(row.Error))
+                        {
+                            <MudText Color="Color.Error" Typo="Typo.caption" Class="oh-error">@row.Error</MudText>
+                        }
+                    </MudItem>
+                </MudGrid>
+            </MudItem>
+        }
+    </MudGrid>
+</MudPaper>
 
 @code {
-	[Parameter] public string? Value { get; set; }
-	[Parameter] public EventCallback<string?> ValueChanged { get; set; }
-	[Parameter] public bool Valid { get; set; }
-	[Parameter] public EventCallback<bool> ValidChanged { get; set; }
+        [Parameter] public string? Value { get; set; }
+        [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+        [Parameter] public bool Valid { get; set; }
+        [Parameter] public EventCallback<bool> ValidChanged { get; set; }
 
-	private readonly (string key, string label)[] DayOrder =
-	[
-		("monday", "Monday"),
-		("tuesday", "Tuesday"),
-		("wednesday", "Wednesday"),
-		("thursday", "Thursday"),
-		("friday", "Friday"),
-		("saturday", "Saturday"),
-		("sunday", "Sunday")
-	];
+        private readonly (string key, string label)[] DayOrder =
+        [
+                ("monday", "Monday"),
+                ("tuesday", "Tuesday"),
+                ("wednesday", "Wednesday"),
+                ("thursday", "Thursday"),
+                ("friday", "Friday"),
+                ("saturday", "Saturday"),
+                ("sunday", "Sunday")
+        ];
 
-	private List<Row> Rows = new();
+        private List<Row> Rows = new();
 
-	private sealed class Row
-	{
-		public string Key { get; init; } = default!;
-		public string Label { get; init; } = default!;
-		public bool Open { get; set; }
-		public TimeOnly Opening { get; set; } = new(7, 30);
-		public TimeOnly Closing { get; set; } = new(16, 0);
-		public string? Error { get; set; }
-	}
+        private sealed class Row
+        {
+                public string Key { get; init; } = default!;
+                public string Label { get; init; } = default!;
+                public bool Open { get; set; }
+                public TimeSpan Opening { get; set; } = new(7, 30, 0);
+                public TimeSpan Closing { get; set; } = new(16, 0, 0);
+                public string? Error { get; set; }
+        }
 
-	protected override void OnInitialized()
-	{
-		Rows = DayOrder.Select(d => new Row
-		{
-			Key = d.key,
-			Label = d.label,
-			Open = d.key is "saturday" or "sunday" ? false : true,
-			Opening = new TimeOnly(7, 30),
-			Closing = new TimeOnly(16, 0)
-		}).ToList();
+        protected override void OnInitialized()
+        {
+                Rows = DayOrder.Select(d => new Row
+                {
+                        Key = d.key,
+                        Label = d.label,
+                        Open = d.key is "saturday" or "sunday" ? false : true,
+                        Opening = new TimeSpan(7, 30, 0),
+                        Closing = new TimeSpan(16, 0, 0)
+                }).ToList();
 
-		TryLoadJson(Value);
-		ValidateAll();
-	}
+                TryLoadJson(Value);
+                ValidateAll();
+        }
 
-	protected override void OnParametersSet()
-	{
-		if (!string.IsNullOrWhiteSpace(Value)) 
-		{
-			TryLoadJson(Value);
-			ValidateAll();
-		}
-	}
+        protected override void OnParametersSet()
+        {
+                if (!string.IsNullOrWhiteSpace(Value))
+                {
+                        TryLoadJson(Value);
+                        ValidateAll();
+                }
+        }
 
-	private void TryLoadJson(string? json)
-	{
-		if (string.IsNullOrWhiteSpace(json)) return;
+        private void TryLoadJson(string? json)
+        {
+                if (string.IsNullOrWhiteSpace(json)) return;
 
-		try
-		{
-			var root = JsonNode.Parse(json)?.AsObject();
-			if (root is null) return;
+                try
+                {
+                        var root = JsonNode.Parse(json)?.AsObject();
+                        if (root is null) return;
 
-			foreach (var r in Rows)
-			{
-				if (!root.TryGetPropertyValue(r.Key, out var node) || node is null)
-					continue;
+                        foreach (var r in Rows)
+                        {
+                                if (!root.TryGetPropertyValue(r.Key, out var node) || node is null)
+                                        continue;
 
-				if (node is JsonObject obj)
-				{
-					r.Open = obj["open"]?.GetValue<bool?>() ?? false;
-					r.Opening = ParseTime(obj["start"]?.GetValue<string>());
-					r.Closing = ParseTime(obj["end"]?.GetValue<string>());
-				}
-				else if (node is JsonArray arr && arr.Count > 0 && arr[0] is JsonObject first)
-				{
-					r.Open = true;
-					r.Opening = ParseTime(first["start"]?.GetValue<string>());
-					r.Closing = ParseTime(first["end"]?.GetValue<string>());
-				}
-			}
-		}
-		catch
-		{
+                                if (node is JsonObject obj)
+                                {
+                                        r.Open = obj["open"]?.GetValue<bool?>() ?? false;
+                                        r.Opening = ParseTime(obj["start"]?.GetValue<string>());
+                                        r.Closing = ParseTime(obj["end"]?.GetValue<string>());
+                                }
+                                else if (node is JsonArray arr && arr.Count > 0 && arr[0] is JsonObject first)
+                                {
+                                        r.Open = true;
+                                        r.Opening = ParseTime(first["start"]?.GetValue<string>());
+                                        r.Closing = ParseTime(first["end"]?.GetValue<string>());
+                                }
+                        }
+                }
+                catch
+                {
 
-		}
-	}
+                }
+        }
 
-	private static TimeOnly RoundToNearestFiveMinutes(TimeOnly time)
-	{
-		var totalMinutes = time.Hour * 60 + time.Minute;
-		var roundedMinutes = ((totalMinutes + 2) / 5) * 5;
+        private static TimeSpan RoundToNearestFiveMinutes(TimeSpan time)
+        {
+                var totalMinutes = (int)Math.Round(time.TotalMinutes);
+                var roundedMinutes = ((totalMinutes + 2) / 5) * 5;
 
-		var hours = roundedMinutes / 60;
-		var minutes = roundedMinutes % 60;
+                var hours = roundedMinutes / 60;
+                var minutes = roundedMinutes % 60;
 
-		if (hours >= 24)
-		{
-			hours = 23;
-			minutes = 55;
-		}
+                if (hours >= 24)
+                {
+                        hours = 23;
+                        minutes = 55;
+                }
 
-		return new TimeOnly(hours, minutes);
-	}
+                return new TimeSpan(hours, minutes, 0);
+        }
 
-	private static TimeOnly ParseTime(string? s)
-	{
-		if (string.IsNullOrWhiteSpace(s)) return new TimeOnly(7, 30);
+        private static TimeSpan ParseTime(string? s)
+        {
+                if (string.IsNullOrWhiteSpace(s)) return new TimeSpan(7, 30, 0);
 
-		TimeOnly time;
-		if (TimeOnly.TryParse(s, out time))
-		{
-			return RoundToNearestFiveMinutes(time);
-		}
+                if (TimeSpan.TryParse(s, out var time))
+                {
+                        return RoundToNearestFiveMinutes(time);
+                }
 
-		if (s?.Length == 4 && int.TryParse(s, out _) && 
-			TimeOnly.TryParseExact(s.Insert(2, ":"), "HH:mm", out time))
-		{
-			return RoundToNearestFiveMinutes(time);
-		}
+                if (s?.Length == 4 && int.TryParse(s, out _) &&
+                        TimeSpan.TryParseExact(s.Insert(2, ":"), "hh\\:mm", null, out time))
+                {
+                        return RoundToNearestFiveMinutes(time);
+                }
 
-		return new TimeOnly(7, 30);
-	}
+                return new TimeSpan(7, 30, 0);
+        }
 
-	private async Task OnRowChanged(Row row)
-	{
-		row.Opening = RoundToNearestFiveMinutes(row.Opening);
-		row.Closing = RoundToNearestFiveMinutes(row.Closing);
+        private Task OnOpenChanged(Row row, bool value)
+        {
+                row.Open = value;
+                return OnRowChanged(row);
+        }
 
-		ValidateRow(row);
-		ValidateAll();
-		await EmitAsync();
-		StateHasChanged();
-	}
+        private Task OnTimeChanged(Row row, TimeSpan? time, bool isOpening)
+        {
+                if (time.HasValue)
+                {
+                        if (isOpening)
+                                row.Opening = time.Value;
+                        else
+                                row.Closing = time.Value;
+                }
+                return OnRowChanged(row);
+        }
 
-	private void ValidateRow(Row r)
-	{
-		r.Error = null;
-		if (!r.Open) return;
-		if (r.Opening >= r.Closing)
-			r.Error = "Opening must be earlier than closing.";
-	}
+        private async Task OnRowChanged(Row row)
+        {
+                row.Opening = RoundToNearestFiveMinutes(row.Opening);
+                row.Closing = RoundToNearestFiveMinutes(row.Closing);
 
-	private void ValidateAll()
-	{
-		foreach (var r in Rows) ValidateRow(r);
-		var ok = Rows.All(r => string.IsNullOrEmpty(r.Error));
-		if (ok != Valid) ValidChanged.InvokeAsync(ok);
-		Valid = ok;
-	}
+                ValidateRow(row);
+                ValidateAll();
+                await EmitAsync();
+                StateHasChanged();
+        }
 
-	private async Task EmitAsync()
-	{
-		var obj = new JsonObject();
-		foreach (var r in Rows)
-		{
-			obj[r.Key] = new JsonObject
-			{
-				["open"] = r.Open,
-				["start"] = r.Opening.ToString("HH\\:mm"),
-				["end"] = r.Closing.ToString("HH\\:mm")
-			};
-		}
-		await ValueChanged.InvokeAsync(obj.ToJsonString());
-	}
+        private void ValidateRow(Row r)
+        {
+                r.Error = null;
+                if (!r.Open) return;
+                if (r.Opening >= r.Closing)
+                        r.Error = "Opening must be earlier than closing.";
+        }
+
+        private void ValidateAll()
+        {
+                foreach (var r in Rows) ValidateRow(r);
+                var ok = Rows.All(r => string.IsNullOrEmpty(r.Error));
+                if (ok != Valid) ValidChanged.InvokeAsync(ok);
+                Valid = ok;
+        }
+
+        private async Task EmitAsync()
+        {
+                var obj = new JsonObject();
+                foreach (var r in Rows)
+                {
+                        obj[r.Key] = new JsonObject
+                        {
+                                ["open"] = r.Open,
+                                ["start"] = r.Opening.ToString(@"hh\\:mm"),
+                                ["end"] = r.Closing.ToString(@"hh\\:mm")
+                        };
+                }
+                await ValueChanged.InvokeAsync(obj.ToJsonString());
+        }
 }
 
 <style>
-	.oh-card {
-		border: 1px solid #eee;
-		border-radius: 8px;
-		padding: 12px;
-		margin-bottom: 12px;
-		background: #fafafa;
-	}
-	.oh-table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-	.oh-table th, .oh-table td {
-		border: 1px solid #f0f0f0;
-		padding: 8px;
-		vertical-align: middle;
-	}
-	.oh-day {
-		font-weight: 600;
-	}
-	.oh-open {
-		text-align: center;
-	}
-	.oh-error {
-		color: #b3261e;
-		font-size: 16px;
-		margin-top: 4px;
-	}
+        .oh-card {
+                padding: 16px;
+                margin-bottom: 12px;
+        }
+        .oh-row {
+                border: 1px solid var(--mud-palette-lines-default);
+                border-radius: 8px;
+                padding: 12px;
+                margin-bottom: 8px;
+        }
+        .oh-day {
+                font-weight: 600;
+        }
+        .oh-open {
+                display: flex;
+                align-items: center;
+        }
+        .oh-picker {
+                width: 100%;
+        }
+        .oh-error {
+                margin-top: 4px;
+                display: block;
+        }
 </style>

--- a/QLine.Web/Components/Pages/Admin/ServicePoints.razor
+++ b/QLine.Web/Components/Pages/Admin/ServicePoints.razor
@@ -45,9 +45,11 @@
                 <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small" OnClick="() => OpenEditDialog(context)" />
                 <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => DeleteAsync(context.Id)" />
                 <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="() => GoToServices(context.Id)">Services</MudButton>
-                <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => OpenStaffModal(context)">
-                    <MudIcon Icon="@Icons.Material.Filled.People" Class="mr-1" />Staff
-                </MudButton>
+                <MudTooltip Text="Assign staff">
+                    <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => OpenStaffModal(context)">
+                        <MudIcon Icon="@Icons.Material.Filled.People" Class="mr-1" />Staff
+                    </MudButton>
+                </MudTooltip>
             </MudTd>
         </RowTemplate>
     </MudTable>


### PR DESCRIPTION
## Summary
- redesign the open hours editor to use MudGrid with switches and time pickers per day while keeping validation and JSON emission
- wrap the staff assignment action in the admin service points table with a tooltip for clarity

## Testing
- `dotnet test QLine.sln` *(fails: dotnet command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3f5a4b5c8320a51a11f252e8e38a)