### PR TITLE
Use chips for role display in admin users table

### DIFF
--- a/QLine.Web/Components/Pages/Admin/Users.razor
+++ b/QLine.Web/Components/Pages/Admin/Users.razor
@@ -47,7 +47,20 @@
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context.Name</MudTd>
                     <MudTd DataLabel="Email">@context.Email</MudTd>
-                    <MudTd DataLabel="Role">@context.Role</MudTd>
+                    <MudTd DataLabel="Role">
+                        @switch (context.Role)
+                        {
+                            case nameof(UserRole.Admin):
+                                <MudChip Color="Color.Success" Variant="Variant.Filled">@context.Role</MudChip>
+                                break;
+                            case nameof(UserRole.Staff):
+                                <MudChip Color="Color.Info" Variant="Variant.Filled">@context.Role</MudChip>
+                                break;
+                            default:
+                                <MudChip Color="Color.Default" Variant="Variant.Filled">@context.Role</MudChip>
+                                break;
+                        }
+                    </MudTd>
                     <MudTd DataLabel="Actions">
                         @if (context.Role == nameof(UserRole.Client))
                         {


### PR DESCRIPTION
## Summary
- display user roles in the admin users table with colored MudChips for each role

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b443ffd40832094b74c723a53220e)