### PR TITLE
Improve auth pages with MudBlazor layout

### DIFF
--- a/QLine.Web/Components/Pages/Auth/Login.razor
+++ b/QLine.Web/Components/Pages/Auth/Login.razor
@@ -1,19 +1,57 @@
-﻿@page "/login"
+@page "/login"
 @inject NavigationManager Nav
 
-<h3>Login</h3>
+<MudGrid Class="auth-grid" Justify="Justify.Center" AlignItems="AlignItems.Center">
+    <MudItem xs="12" sm="8" md="5" lg="4">
+        <MudCard Class="auth-card" Elevation="3">
+            <MudCardContent>
+                <MudText Typo="Typo.h5" GutterBottom="true">Login</MudText>
 
-@if (ErrorCode is not null)
-{
-        <p class="text-danger">@ErrorMessage</p>
-}
+                @if (ErrorCode is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" Class="mb-2">@ErrorMessage</MudAlert>
+                }
 
-<form method="post" action="/auth/login">
-        <input type="hidden" name="returnUrl" value="@ReturnUrl" />
-        <input type="email" name="email" value="@_email" placeholder="email (e.g. staff@qline.local)" />
-        <input type="password" name="password" value="@_password" placeholder="password (e.g. Pass@word1)" style="margin-left:8px;" />
-        <button type="submit" style="margin-left:8px;">Sign in</button>
-</form>
+                <form method="post" action="/auth/login" class="auth-form">
+                    <input type="hidden" name="returnUrl" value="@ReturnUrl" />
+
+                    <MudStack Spacing="1.5">
+                        <MudTextField @bind-Value="_email"
+                                      Label="Email"
+                                      InputType="InputType.Email"
+                                      Name="email"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Email"
+                                      FullWidth="true"
+                                      Placeholder="email (e.g. staff@qline.local)" />
+
+                        <MudTextField @bind-Value="_password"
+                                      Label="Password"
+                                      InputType="InputType.Password"
+                                      Name="password"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Lock"
+                                      FullWidth="true"
+                                      Placeholder="password (e.g. Pass@word1)" />
+
+                        <MudButton Type="ButtonType.Submit"
+                                   Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   FullWidth="true">
+                            Sign in
+                        </MudButton>
+
+                        <MudText Typo="Typo.body2" Align="Align.Center">
+                            New here? <MudLink Href="/register">Create an account</MudLink>
+                        </MudText>
+                    </MudStack>
+                </form>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+</MudGrid>
 
 @code {
         private string _email = "staff@qline.local";
@@ -29,6 +67,6 @@
                 _ => "Sign-in failed"
         };
 
-	private string ReturnUrl =>
-		System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query).Get("returnUrl") ?? "/";
+        private string ReturnUrl =>
+                System.Web.HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query).Get("returnUrl") ?? "/";
 }

--- a/QLine.Web/Components/Pages/Auth/Login.razor.css
+++ b/QLine.Web/Components/Pages/Auth/Login.razor.css
@@ -1,0 +1,12 @@
+.auth-grid {
+    min-height: 100vh;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    margin: 0 auto;
+}
+
+.auth-form {
+    margin-top: 4px;
+}

--- a/QLine.Web/Components/Pages/Auth/Register.razor
+++ b/QLine.Web/Components/Pages/Auth/Register.razor
@@ -1,20 +1,69 @@
 @page "/register"
 @inject NavigationManager Nav
 
-<h3>Register</h3>
+<MudGrid Class="auth-grid" Justify="Justify.Center" AlignItems="AlignItems.Center">
+    <MudItem xs="12" sm="8" md="5" lg="4">
+        <MudCard Class="auth-card" Elevation="3">
+            <MudCardContent>
+                <MudText Typo="Typo.h5" GutterBottom="true">Register</MudText>
 
-@if (ErrorCode is not null)
-{
-        <p class="text-danger">@ErrorMessage</p>
-}
+                @if (ErrorCode is not null)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Variant="Variant.Filled" Class="mb-2">@ErrorMessage</MudAlert>
+                }
 
-<form method="post" action="/auth/register">
-        <input type="text" name="firstName" value="@_firstName" placeholder="First name" />
-        <input type="text" name="lastName" value="@_lastName" placeholder="Last name" style="margin-left:8px;" />
-        <input type="email" name="email" value="@_email" placeholder="email" style="margin-left:8px;" />
-        <input type="password" name="password" value="@_password" placeholder="password" style="margin-left:8px;" />
-        <button type="submit" style="margin-left:8px;">Create account</button>
-</form>
+                <form method="post" action="/auth/register" class="auth-form">
+                    <MudStack Spacing="1.5">
+                        <MudTextField @bind-Value="_firstName"
+                                      Label="First name"
+                                      Name="firstName"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Person"
+                                      FullWidth="true" />
+
+                        <MudTextField @bind-Value="_lastName"
+                                      Label="Last name"
+                                      Name="lastName"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Person"
+                                      FullWidth="true" />
+
+                        <MudTextField @bind-Value="_email"
+                                      Label="Email"
+                                      InputType="InputType.Email"
+                                      Name="email"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Email"
+                                      FullWidth="true" />
+
+                        <MudTextField @bind-Value="_password"
+                                      Label="Password"
+                                      InputType="InputType.Password"
+                                      Name="password"
+                                      Required="true"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Lock"
+                                      FullWidth="true" />
+
+                        <MudButton Type="ButtonType.Submit"
+                                   Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   FullWidth="true">
+                            Create account
+                        </MudButton>
+
+                        <MudText Typo="Typo.body2" Align="Align.Center">
+                            Already have an account? <MudLink Href="/login">Sign in</MudLink>
+                        </MudText>
+                    </MudStack>
+                </form>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+</MudGrid>
 
 @code {
         private string _firstName = "";

--- a/QLine.Web/Components/Pages/Auth/Register.razor.css
+++ b/QLine.Web/Components/Pages/Auth/Register.razor.css
@@ -1,0 +1,12 @@
+.auth-grid {
+    min-height: 100vh;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    margin: 0 auto;
+}
+
+.auth-form {
+    margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- Rebuild the login and register Razor pages with centered MudGrid and compact MudCard layouts
- Replace basic inputs with MudTextField components, adorned icons, and full-width primary submit buttons plus navigation links
- Add scoped styling to ensure full-height centering and consistent ~400px card widths

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c115378008320aa0ceacf2bedd721)