### PR TITLE
Add search and card layout for service listings

### DIFF
--- a/QLine.Web/Components/Pages/ServicePoints.razor
+++ b/QLine.Web/Components/Pages/ServicePoints.razor
@@ -6,55 +6,73 @@
 @inject IMediator Mediator
 @inject NavigationManager Nav
 
-<h3>Service Points</h3>
+<MudStack Spacing="3">
+    <MudText Typo="Typo.h4" Class="font-weight-bold">Service Points</MudText>
 
-@if (_loading)
-{
-	<p>Loading...</p>
-}
-else if (!string.IsNullOrWhiteSpace(_errorMessage))
-{
-	<ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
-}
-else if (_points.Count == 0)
-{
-	<p>No service points.</p>
-}
-else
-{
-	<ul>
-		@foreach (var sp in _points)
-		{
-			<li>
-				<strong>@sp.Name</strong>
-				<div>@sp.Address</div>
-				<button @onclick="() => GoToServices(sp.Id)">View services</button>
-			</li>
-		}
-	</ul>
-}
+    <MudTextField @bind-Value="_searchTerm"
+                  Placeholder="Search service points"
+                  Adornment="Adornment.Start"
+                  AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" />
+
+    @if (_loading)
+    {
+        <p>Loading...</p>
+    }
+    else if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+    }
+    else if (!FilteredServicePoints.Any())
+    {
+        <p>No service points.</p>
+    }
+    else
+    {
+        <MudGrid GutterSize="GutterSize.Small">
+            @foreach (var sp in FilteredServicePoints)
+            {
+                <MudItem xs="12" sm="6" md="4">
+                    <MudCard Class="mud-elevation-1 hover:mud-elevation-4 cursor-pointer" @onclick="() => GoToServices(sp.Id)">
+                        <MudCardContent>
+                            <MudText Typo="Typo.h6" Class="font-weight-bold">@sp.Name</MudText>
+                            <MudText Color="Color.TextSecondary">@sp.Address</MudText>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            }
+        </MudGrid>
+    }
+</MudStack>
 @code {
     private bool _loading = true;
-	private string? _errorMessage;
-	private List<string>? _errorDetails;
-	private List<ServicePointDto> _points = new();
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+    private string _searchTerm = string.Empty;
+    private List<ServicePointDto> _points = new();
 
-	protected override async Task OnInitializedAsync()
-	{
-		_errorMessage = null;
-		_errorDetails = null;
+    private IEnumerable<ServicePointDto> FilteredServicePoints =>
+        _points.Where(sp =>
+            string.IsNullOrWhiteSpace(_searchTerm) ||
+            sp.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
+            sp.Address.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
-            try
-            {
-                    _points = (await Mediator.Send(new GetServicePointsQuery())).ToList();
-            }
-		catch (Exception ex)
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
-		finally { _loading = false; }
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        _errorMessage = null;
+        _errorDetails = null;
 
-	private void GoToServices(Guid servicePointId)
-	=> Nav.NavigateTo($"/services/{servicePointId}");
+        try
+        {
+            _points = (await Mediator.Send(new GetServicePointsQuery())).ToList();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+        finally { _loading = false; }
+    }
+
+    private void GoToServices(Guid servicePointId)
+        => Nav.NavigateTo($"/services/{servicePointId}");
 }

--- a/QLine.Web/Components/Pages/Services.razor
+++ b/QLine.Web/Components/Pages/Services.razor
@@ -5,60 +5,77 @@
 @inject IMediator Mediator
 @inject NavigationManager Nav
 
-<h3>Services</h3>
+<MudStack Spacing="3">
+    <MudText Typo="Typo.h4" Class="font-weight-bold">Services</MudText>
 
-@if (_loading)
-{
-	<p>Loading...</p>
-}
-else if (!string.IsNullOrWhiteSpace(_errorMessage))
-{
-	<ErrorAlert Message="@_errorMessage" Details="_errorDetails" />
-}
-else if (_services.Count == 0)
-{
-	<p>No services for this service point.</p>
-}
-else
-{
-	<ul>
-		@foreach (var s in _services)
-		{
-			<li>
-				<strong>@s.Name</strong>
-				<div>Duration: @s.DurationMin min, Buffer: @s.BufferMin min</div>
-				<button @onclick="() => GoToReserve(ServicePointId, s.Id)">Reserve</button>
-			</li>
-		}
-	</ul>
-}
+    <MudTextField @bind-Value="_searchTerm"
+                  Placeholder="Search services"
+                  Adornment="Adornment.Start"
+                  AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" />
+
+    @if (_loading)
+    {
+        <p>Loading...</p>
+    }
+    else if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+    }
+    else if (!FilteredServices.Any())
+    {
+        <p>No services for this service point.</p>
+    }
+    else
+    {
+        <MudGrid GutterSize="GutterSize.Small">
+            @foreach (var s in FilteredServices)
+            {
+                <MudItem xs="12" sm="6" md="4">
+                    <MudCard Class="mud-elevation-1 hover:mud-elevation-4 cursor-pointer" @onclick="() => GoToReserve(ServicePointId, s.Id)">
+                        <MudCardContent>
+                            <MudText Typo="Typo.h6" Class="font-weight-bold">@s.Name</MudText>
+                            <MudText Color="Color.TextSecondary">Duration: @s.DurationMin min, Buffer: @s.BufferMin min</MudText>
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            }
+        </MudGrid>
+    }
+</MudStack>
 
 @code {
-	[Parameter] public Guid ServicePointId { get; set; }
+    [Parameter] public Guid ServicePointId { get; set; }
 
-	private bool _loading = true;
-	private string? _errorMessage;
-	private List<string>? _errorDetails;
-	private List<ServiceDto> _services = new();
+    private bool _loading = true;
+    private string? _errorMessage;
+    private List<string>? _errorDetails;
+    private string _searchTerm = string.Empty;
+    private List<ServiceDto> _services = new();
 
-	protected override async Task OnParametersSetAsync()
-	{
-		_loading = true;
-		_errorMessage = null;
-		_errorDetails = null;
-		_services.Clear();
+    private IEnumerable<ServiceDto> FilteredServices =>
+        _services.Where(s =>
+            string.IsNullOrWhiteSpace(_searchTerm) ||
+            s.Name.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase));
 
-		try
-		{
-			_services = (await Mediator.Send(new GetServicesForServicePointQuery(ServicePointId))).ToList();
-		}
-		catch (Exception ex) 
-		{
-			(_errorMessage, _errorDetails) = ex.ToUserMessage();
-		}
-		finally { _loading = false; }
-	}
+    protected override async Task OnParametersSetAsync()
+    {
+        _loading = true;
+        _errorMessage = null;
+        _errorDetails = null;
+        _services.Clear();
 
-	private void GoToReserve(Guid servicePointId, Guid serviceId)
-		=> Nav.NavigateTo($"/reserve/{servicePointId}/{serviceId}");
+        try
+        {
+            _services = (await Mediator.Send(new GetServicesForServicePointQuery(ServicePointId))).ToList();
+        }
+        catch (Exception ex)
+        {
+            (_errorMessage, _errorDetails) = ex.ToUserMessage();
+        }
+        finally { _loading = false; }
+    }
+
+    private void GoToReserve(Guid servicePointId, Guid serviceId)
+        => Nav.NavigateTo($"/reserve/{servicePointId}/{serviceId}");
 }


### PR DESCRIPTION
## Summary
- replace service point and service lists with MudGrid card layouts
- add search fields with search icon adornments to filter service points and services
- preserve navigation by making cards clickable to view services or reserve

## Testing
- dotnet test QLine.sln *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c155cf31883208770e72104a2c5b6)