### PR TITLE
Restyle display selection and board layouts

### DIFF
--- a/QLine.Web/Components/Pages/Display.razor
+++ b/QLine.Web/Components/Pages/Display.razor
@@ -13,64 +13,64 @@
 
 @if (_isLoading)
 {
-    <p>Loading display...</p>
+    <div class="display-loading">
+        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Class="mb-4" />
+        <MudText Typo="Typo.h5">Loading display...</MudText>
+    </div>
 }
 else if (!string.IsNullOrWhiteSpace(_errorMessage))
 {
     <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
-    <a class="btn btn-outline-primary mt-3" href="/display">Back to display menu</a>
+    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Href="/display" Class="mt-3">Back to display menu</MudButton>
 }
 else if (_snapshot is null)
 {
-    <p>Queue data is unavailable right now.</p>
+    <div class="display-loading">
+        <MudText Typo="Typo.h5">Queue data is unavailable right now.</MudText>
+    </div>
 }
 else
 {
-    <div class="display-board">
-        <section class="now-serving">
-            <div class="section-header">
-                <div>
-                    <div class="section-label">Now Serving</div>
-                    @if (!string.IsNullOrWhiteSpace(_servicePointName))
-                    {
-                        <div class="section-point">@_servicePointName</div>
-                    }
-                </div>
+    <MudGrid Spacing="0" Class="display-grid">
+        <MudItem Xs="12" Md="8" Class="now-serving-panel">
+            <div class="panel-content">
+                <MudText Typo="Typo.h4" Class="section-label" Color="Color.Secondary">Now Serving</MudText>
+                @if (!string.IsNullOrWhiteSpace(_servicePointName))
+                {
+                    <MudText Typo="Typo.subtitle1" Class="section-point" Color="Color.Info">@_servicePointName</MudText>
+                }
+
+                @if (_snapshot.Current is null)
+                {
+                    <MudText Typo="Typo.h3" Class="placeholder-text">Please wait</MudText>
+                }
+                else
+                {
+                    <MudText Typo="Typo.h1" Class="ticket-number">@_snapshot.Current.TicketNo</MudText>
+                }
             </div>
+        </MudItem>
+        <MudItem Xs="12" Md="4" Class="up-next-panel">
+            <div class="panel-content">
+                <MudText Typo="Typo.h5" Class="section-label" Color="Color.Primary">Up Next</MudText>
+                <MudText Typo="Typo.subtitle2" Class="section-subtitle">Next clients in line</MudText>
 
-            @if (_snapshot.Current is null)
-            {
-                <div class="now-serving-placeholder">
-                    <div class="placeholder-text">Please wait</div>
-                </div>
-            }
-            else
-            {
-                <div class="ticket-number">@_snapshot.Current.TicketNo</div>
-            }
-        </section>
-
-        <section class="up-next">
-            <div class="section-header">
-                <div class="section-label">Up Next</div>
-                <div class="section-subtitle">Next clients in line</div>
+                @if (_snapshot.Waiting.Count == 0)
+                {
+                    <MudText Typo="Typo.subtitle1" Class="placeholder-text">(empty)</MudText>
+                }
+                else
+                {
+                    <MudList T="string" Class="up-next-list" DisableGutters="true">
+                        @foreach (var ticket in _snapshot.Waiting.Take(6))
+                        {
+                            <MudListItem Class="up-next-item">@ticket.TicketNo</MudListItem>
+                        }
+                    </MudList>
+                }
             </div>
-
-            @if (_snapshot.Waiting.Count == 0)
-            {
-                <div class="empty">(empty)</div>
-            }
-            else
-            {
-                <ul class="up-next-list">
-                    @foreach (var w in _snapshot.Waiting.Take(5))
-                    {
-                        <li class="up-next-item">@w.TicketNo</li>
-                    }
-                </ul>
-            }
-        </section>
-    </div>
+        </MudItem>
+    </MudGrid>
 }
 
 @code {
@@ -193,3 +193,89 @@ else
             await _realtimeHandle.InvokeVoidAsync("dispose");
     }
 }
+
+<style>
+    .display-grid {
+        height: 100vh;
+        background: linear-gradient(135deg, #0f172a 0%, #0b2847 50%, #0f172a 100%);
+        color: #ffffff;
+    }
+
+    .now-serving-panel,
+    .up-next-panel {
+        height: 100vh;
+        display: flex;
+        align-items: center;
+    }
+
+    .now-serving-panel {
+        background: rgba(10, 25, 47, 0.92);
+        border-right: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .up-next-panel {
+        background: #f7f8fb;
+        color: #111827;
+    }
+
+    .panel-content {
+        width: 100%;
+        padding: clamp(32px, 6vw, 72px);
+    }
+
+    .section-label {
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        opacity: 0.9;
+    }
+
+    .section-point {
+        margin-top: 8px;
+        font-weight: 600;
+    }
+
+    .ticket-number {
+        font-size: clamp(72px, 14vw, 160px);
+        font-weight: 800;
+        letter-spacing: 6px;
+        margin-top: clamp(32px, 4vw, 64px);
+        text-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+    }
+
+    .placeholder-text {
+        opacity: 0.85;
+    }
+
+    .up-next-list {
+        margin-top: 16px;
+        background: transparent;
+    }
+
+    .up-next-item {
+        font-size: clamp(28px, 3vw, 48px);
+        font-weight: 700;
+        padding: 12px 0;
+        border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    }
+
+    .display-loading {
+        min-height: 60vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+    }
+
+    @media (max-width: 960px) {
+        .display-grid,
+        .now-serving-panel,
+        .up-next-panel {
+            height: auto;
+        }
+
+        .now-serving-panel {
+            border-right: none;
+        }
+    }
+</style>

--- a/QLine.Web/Components/Pages/DisplaySelection.razor
+++ b/QLine.Web/Components/Pages/DisplaySelection.razor
@@ -8,51 +8,62 @@
 
 <PageTitle>Display Menu</PageTitle>
 
-<h3>Display Boards</h3>
-
-@if (_loading)
-{
-    <p>Loading service points...</p>
-}
-else if (!string.IsNullOrWhiteSpace(_errorMessage))
-{
-    <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
-}
-else if (_servicePoints.Count == 0)
-{
-    <p>No service points available.</p>
-}
-else
-{
-    <div class="row g-4">
-        @foreach (var sp in _servicePoints)
+<div class="display-selection-wrapper">
+    <MudContainer MaxWidth="MaxWidth.Medium">
+        @if (_loading)
         {
-            <div class="col-md-6 col-lg-4">
-                <div class="card h-100 shadow-sm">
-                    <div class="card-body d-flex flex-column">
-                        <h5 class="card-title">@sp.Name</h5>
-                        <p class="card-text text-muted">@sp.Address</p>
-                        <div class="mt-auto">
-                            <a class="btn btn-primary w-100" href="/display/@sp.Id" target="_blank" rel="noopener noreferrer">Open Board</a>
-                        </div>
-                    </div>
-                </div>
+            <div class="display-selection-loading">
+                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Class="mb-3" />
+                <MudText Typo="Typo.subtitle1" Color="Color.Primary">Loading service points...</MudText>
             </div>
         }
-    </div>
-}
+        else if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <ErrorAlert Message="@_errorMessage" Details="@_errorDetails" />
+        }
+        else if (_servicePoints.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info" Variant="Variant.Filled" Elevation="0">No service points available.</MudAlert>
+        }
+        else
+        {
+            <MudCard Class="display-selection-card" Elevation="8">
+                <MudCardContent>
+                    <MudText Typo="Typo.h5" GutterBottom="true">Open Display Board</MudText>
+                    <MudText Typo="Typo.subtitle1" Class="mb-4">Select a service point to launch its display.</MudText>
+                    <MudSelect T="Guid?" Label="Service Point" @bind-Value="_selectedServicePoint" Dense="false" FullWidth="true" Required="true" DisableUnderline="true">
+                        @foreach (var sp in _servicePoints)
+                        {
+                            <MudSelectItem Value="@sp.Id">@sp.Name (@sp.Address)</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudCardContent>
+                <MudCardActions Class="display-selection-actions">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true"
+                               Disabled="!_selectedServicePoint.HasValue"
+                               Href="@(_selectedServicePoint is Guid id ? $"/display/{id}" : null)"
+                               Target="_blank" Rel="noopener noreferrer">
+                        Start
+                    </MudButton>
+                </MudCardActions>
+            </MudCard>
+        }
+    </MudContainer>
+</div>
 
 @code {
     private bool _loading = true;
     private string? _errorMessage;
     private List<string>? _errorDetails;
     private List<ServicePointDto> _servicePoints = new();
+    private Guid? _selectedServicePoint;
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
             _servicePoints = (await Mediator.Send(new GetServicePointsQuery())).ToList();
+            _selectedServicePoint = _servicePoints.FirstOrDefault()?.Id;
         }
         catch (Exception ex)
         {
@@ -64,3 +75,31 @@ else
         }
     }
 }
+
+<style>
+    .display-selection-wrapper {
+        min-height: calc(100vh - 120px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px 16px;
+    }
+
+    .display-selection-card {
+        padding: 12px 12px 4px;
+        border-radius: 16px;
+    }
+
+    .display-selection-actions {
+        padding: 0 16px 16px;
+    }
+
+    .display-selection-loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 48px 0;
+        gap: 8px;
+    }
+</style>


### PR DESCRIPTION
## Summary
- Center the display selection experience in a MudCard with a service point selector and prominent start action
- Redesign the display board as a full-screen MudGrid with high-contrast Now Serving and Up Next sections for large screens

## Testing
- `dotnet test` *(fails: dotnet command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c163d9dfc8320aeac8acd0e9821c6)